### PR TITLE
Get + Save Fiat Currencies from fiat-rates.json

### DIFF
--- a/ARK Rate/Sources/Core/Data/DTO/CurrencyDTO.swift
+++ b/ARK Rate/Sources/Core/Data/DTO/CurrencyDTO.swift
@@ -1,13 +1,15 @@
+import Foundation
+
 struct CurrencyDTO {
 
-    enum Category {
+    enum Category: String {
         case fiat
         case crypto
     }
 
     // MARK: - Properties
 
-    let id: String
-    let rate: Double
+    let code: String
+    let rate: Decimal
     let category: Category
 }

--- a/ARK Rate/Sources/Core/Data/DataSources/FiatCurrencyDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/FiatCurrencyDataSource.swift
@@ -15,8 +15,6 @@ final class FiatCurrencyDataSource: CurrencyRemoteDataSource {
     // MARK: - Conformance
 
     func fetch() async throws -> [CurrencyDTO] {
-        try await apiClient.fetch().rates.map {
-            CurrencyDTO(id: $0.key, rate: $0.value, category: CurrencyDTO.Category.fiat)
-        }
+        try await apiClient.fetch().toCurrencyDTOs
     }
 }

--- a/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
@@ -7,11 +7,11 @@ struct CurrencySwiftDataDataSource: CurrencyLocalDataSource {
 
     func get() throws -> [CurrencyDTO] {
         let models = try SwiftDataManager.shared.get()
-        return models.map { CurrencyDTO(id: $0.id, rate: $0.rate, category: CurrencyDTO.Category.fiat) }
+        return models.map { $0.toCurrencyDTO }
     }
 
     func save(_ currencies: [CurrencyDTO]) throws {
-        let models = currencies.map { CurrencyModel(id: $0.id, rate: $0.rate) }
+        let models = currencies.map { $0.toCurrencyModel }
         try SwiftDataManager.shared.insert(models)
     }
 }

--- a/ARK Rate/Sources/Core/Data/Local/Models/CurrencyModel.swift
+++ b/ARK Rate/Sources/Core/Data/Local/Models/CurrencyModel.swift
@@ -1,12 +1,15 @@
+import Foundation
 import SwiftData
 
 @Model
 final class CurrencyModel {
-    @Attribute(.unique) var id: String
-    var rate: Double
+    @Attribute(.unique) var code: String
+    var rate: Decimal
+    var categoryRaw: String
 
-    init(id: String, rate: Double) {
-        self.id = id
+    init(code: String, rate: Decimal, categoryRaw: String) {
+        self.code = code
         self.rate = rate
+        self.categoryRaw = categoryRaw
     }
 }

--- a/ARK Rate/Sources/Core/Data/Mappers/CurrencyMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/CurrencyMapper.swift
@@ -1,0 +1,53 @@
+// MARK: -
+
+extension CurrencyDTO {
+
+    var toCurrency: Currency {
+        let category: Currency.Category
+        switch self.category {
+        case .fiat: category = Currency.Category.fiat
+        case .crypto: category = Currency.Category.crypto
+        }
+        return Currency(
+            code: code,
+            rate: rate,
+            category: category
+        )
+    }
+
+    var toCurrencyModel: CurrencyModel {
+        CurrencyModel(
+            code: code,
+            rate: rate,
+            categoryRaw: category.rawValue
+        )
+    }
+}
+
+// MARK: -
+
+extension FiatCurrenciesRateResponse {
+
+    var toCurrencyDTOs: [CurrencyDTO] {
+        rates.map {
+            CurrencyDTO(
+                code: $0.key,
+                rate: $0.value,
+                category: CurrencyDTO.Category.fiat
+            )
+        }
+    }
+}
+
+// MARK: -
+
+extension CurrencyModel {
+
+    var toCurrencyDTO: CurrencyDTO {
+        CurrencyDTO(
+            code: code,
+            rate: rate,
+            category: CurrencyDTO.Category(rawValue: categoryRaw)!
+        )
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Network/API/FiatCurrenciesRateAPI.swift
+++ b/ARK Rate/Sources/Core/Data/Network/API/FiatCurrenciesRateAPI.swift
@@ -5,11 +5,13 @@ protocol FiatCurrenciesRateAPI {
     func fetch() async throws -> FiatCurrenciesRateResponse
 }
 
+// MARK: -
+
 final class FiatCurrenciesRateAPIClient: FiatCurrenciesRateAPI {
 
     // MARK: - Constants
 
-    private let endpoint = "https://open.er-api.com/v6/latest/USD"
+    private let endpoint = "https://raw.githubusercontent.com/ARK-Builders/ark-exchange-rates/main/fiat-rates.json"
 
     // MARK: - Conformance
 

--- a/ARK Rate/Sources/Core/Data/Network/DTO/FiatCurrenciesRateResponse.swift
+++ b/ARK Rate/Sources/Core/Data/Network/DTO/FiatCurrenciesRateResponse.swift
@@ -1,12 +1,9 @@
+import Foundation
+
 struct FiatCurrenciesRateResponse: Decodable {
 
     // MARK: - Properties
 
-    let rates: [String: Double]
-
-    // MARK: - Methods
-
-    func toDomain() -> [Currency] {
-        return rates.map { Currency(id: $0.key, rate: $0.value, category: Currency.Category.fiat) }
-    }
+    let timestamp: TimeInterval
+    let rates: [String: Decimal]
 }

--- a/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
@@ -16,15 +16,15 @@ final class CurrencyRepositoryImpl: CurrencyRepository {
 
     func getLocal() throws -> [Currency] {
         try localDataSource.get()
-            .map { Currency(id: $0.id, rate: $0.rate, category: Currency.Category.fiat) }
-            .sorted { $0.id < $1.id }
+            .map { $0.toCurrency }
+            .sorted { $0.code < $1.code }
     }
 
     func fetchRemote() async throws -> [Currency] {
         let currencies = try await fiatCurrencyDataSource.fetch()
         try localDataSource.save(currencies)
         return currencies
-            .map { Currency(id: $0.id, rate: $0.rate, category: Currency.Category.fiat) }
-            .sorted { $0.id < $1.id }
+            .map { $0.toCurrency }
+            .sorted { $0.code < $1.code }
     }
 }

--- a/ARK Rate/Sources/Core/Domain/Entities/Currency.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/Currency.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct Currency {
 
     enum Category {
@@ -7,7 +9,7 @@ struct Currency {
 
     // MARK: - Properties
 
-    let id: String
-    let rate: Double
+    let code: String
+    let rate: Decimal
     let category: Category
 }

--- a/ARK Rate/Sources/Core/Presentation/Extensions/Decimal+FinancialRate.swift
+++ b/ARK Rate/Sources/Core/Presentation/Extensions/Decimal+FinancialRate.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Decimal {
+
+    private static let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 6
+        return formatter
+    }()
+
+    var formattedRate: String {
+        return Decimal.formatter.string(from: self as NSDecimalNumber) ?? "\(self)"
+    }
+}

--- a/ARK Rate/Sources/Features/Currencies/CurrencyDisplayModel.swift
+++ b/ARK Rate/Sources/Features/Currencies/CurrencyDisplayModel.swift
@@ -8,7 +8,7 @@ struct CurrencyDisplayModel: Identifiable, Equatable {
     // MARK: - Initialization
 
     init(from fiatCurrency: Currency) {
-        self.id = fiatCurrency.id
-        self.formattedRate = String(format: "%.2f", fiatCurrency.rate)
+        self.id = fiatCurrency.code
+        self.formattedRate = fiatCurrency.rate.formattedRate
     }
 }


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Get Fiat Currencies from fiat-rates.json
- Save response to local
- Update Models

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[Get + Save Fiat Currencies from fiat-rates.json](https://app.asana.com/0/1209031794063268/1209638454266834)
