### PR TITLE
[Quick] Add Calculations section to Quick screen

### DIFF
--- a/ARK Rate/Assets.xcassets/Colors/Teal600.colorset/Contents.json
+++ b/ARK Rate/Assets.xcassets/Colors/Teal600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x85",
+          "green" : "0x94",
+          "red" : "0x0D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ARK Rate/Assets.xcassets/Colors/Teal700.colorset/Contents.json
+++ b/ARK Rate/Assets.xcassets/Colors/Teal700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x44",
+          "green" : "0x75",
+          "red" : "0x0F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ARK Rate/Localizable.xcstrings
+++ b/ARK Rate/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%lld+" : {
+
+    },
     "add_group" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -355,6 +358,28 @@
         }
       }
     },
+    "calculated_on_ago" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calculated on %@ ago"
+          }
+        }
+      }
+    },
+    "calculations" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calculations"
+          }
+        }
+      }
+    },
     "CDF" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -538,6 +563,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Egyptian Pound"
+          }
+        }
+      }
+    },
+    "elapsed_day" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld day"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%lld days"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "elapsed_hour" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld hour"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld hours"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "elapsed_minute" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld minute"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld minutes"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "elapsed_second" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld second"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld seconds"
+                }
+              }
+            }
           }
         }
       }

--- a/ARK Rate/Sources/Core/Data/DTO/QuickCalculationDTO.swift
+++ b/ARK Rate/Sources/Core/Data/DTO/QuickCalculationDTO.swift
@@ -4,6 +4,8 @@ struct QuickCalculationDTO {
 
     // MARK: - Properties
 
+    let id: UUID
+    let calculatedDate: Date
     let inputCurrencyCode: String
     let inputCurrencyAmount: Decimal
     let outputCurrenciesCode: [String]

--- a/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationModel.swift
+++ b/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationModel.swift
@@ -7,6 +7,7 @@ final class QuickCalculationModel {
     // MARK: - Properties
 
     @Attribute(.unique) var id: UUID
+    var calculatedDate: Date
     var inputCurrencyCode: String
     var inputCurrencyAmount: Decimal
     var outputCurrenciesCode: [String]
@@ -14,12 +15,14 @@ final class QuickCalculationModel {
     // MARK: - Initialization
 
     init(
-        id: UUID = UUID(),
+        id: UUID,
+        calculatedDate: Date,
         inputCurrencyCode: String,
         inputCurrencyAmount: Decimal,
         outputCurrenciesCode: [String]
     ) {
         self.id = id
+        self.calculatedDate = calculatedDate
         self.inputCurrencyCode = inputCurrencyCode
         self.inputCurrencyAmount = inputCurrencyAmount
         self.outputCurrenciesCode = outputCurrenciesCode

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -4,6 +4,8 @@ extension QuickCalculation {
 
     var toQuickCalculationDTO: QuickCalculationDTO {
         QuickCalculationDTO(
+            id: id,
+            calculatedDate: calculatedDate,
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrenciesCode: outputCurrenciesCode
@@ -17,6 +19,8 @@ extension QuickCalculationDTO {
 
     var toQuickCalculation: QuickCalculation {
         QuickCalculation(
+            id: id,
+            calculatedDate: calculatedDate,
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrenciesCode: outputCurrenciesCode
@@ -25,6 +29,8 @@ extension QuickCalculationDTO {
 
     var toQuickCalculationModel: QuickCalculationModel {
         QuickCalculationModel(
+            id: id,
+            calculatedDate: calculatedDate,
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrenciesCode: outputCurrenciesCode
@@ -38,6 +44,8 @@ extension QuickCalculationModel {
 
     var toQuickCalculationDTO: QuickCalculationDTO {
         QuickCalculationDTO(
+            id: id,
+            calculatedDate: calculatedDate,
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrenciesCode: outputCurrenciesCode

--- a/ARK Rate/Sources/Core/Domain/Entities/QuickCalculation.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/QuickCalculation.swift
@@ -4,7 +4,31 @@ struct QuickCalculation: Equatable {
 
     // MARK: - Properties
 
+    let id: UUID
+    let calculatedDate: Date
     let inputCurrencyCode: String
     let inputCurrencyAmount: Decimal
     let outputCurrenciesCode: [String]
+
+    // MARK: - Initialization
+
+    init(
+        id: UUID = UUID(),
+        calculatedDate: Date = Date(),
+        inputCurrencyCode: String,
+        inputCurrencyAmount: Decimal,
+        outputCurrenciesCode: [String]
+    ) {
+        self.id = id
+        self.calculatedDate = calculatedDate
+        self.inputCurrencyCode = inputCurrencyCode
+        self.inputCurrencyAmount = inputCurrencyAmount
+        self.outputCurrenciesCode = outputCurrenciesCode
+    }
+
+    // MARK: - Conformance
+
+    static func == (lhs: QuickCalculation, rhs: QuickCalculation) -> Bool {
+        return lhs.id == rhs.id
+    }
 }

--- a/ARK Rate/Sources/Core/Domain/UseCases/CurrencyCalculationUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/CurrencyCalculationUseCase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-typealias CurrencyAmounts = [String: Decimal]
+typealias CurrencyAmounts = [String: String]
 
 protocol CurrencyCalculationUseCase {
 
@@ -23,7 +23,7 @@ struct CurrencyCalculationUseCaseImpl: CurrencyCalculationUseCase {
         var currencyAmounts: CurrencyAmounts = [:]
         outputCurrencies.forEach { outputCurrency in
             let rate = inputCurrency.rate.divideArk(outputCurrency.rate)
-            currencyAmounts[outputCurrency.code] = inputCurrencyAmount * rate
+            currencyAmounts[outputCurrency.code] = (inputCurrencyAmount * rate).formattedRate
         }
         return currencyAmounts
     }

--- a/ARK Rate/Sources/Core/Presentation/Components/CurrencyCalculationRowView.swift
+++ b/ARK Rate/Sources/Core/Presentation/Components/CurrencyCalculationRowView.swift
@@ -110,22 +110,6 @@ private extension CurrencyCalculationRowView {
             .buttonStyle(.plain)
         }
     }
-
-    func makeImage(code: String, size: CGFloat) -> some View {
-        Image.image(code)
-            .resizable()
-            .frame(width: size, height: size)
-            .modifier(CircleBorderModifier())
-    }
-
-    @ViewBuilder
-    private func additionalBadgeContent<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        if !isExpanded {
-            content()
-                .offset(x: Constants.badgeImageOffset)
-                .padding(.trailing, Constants.badgeImageOffset)
-        }
-    }
 }
 
 // MARK: - Helpers
@@ -147,6 +131,22 @@ private extension CurrencyCalculationRowView {
     var subtitle: String {
         let remaining = isExpanded ? "" : "\(outputs.first?.formattedAmount ?? "")"
         return "\(input.formattedAmount) = \(remaining)"
+    }
+
+    func makeImage(code: String, size: CGFloat) -> some View {
+        Image.image(code)
+            .resizable()
+            .frame(width: size, height: size)
+            .modifier(CircleBorderModifier())
+    }
+
+    @ViewBuilder
+    func additionalBadgeContent<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        if !isExpanded {
+            content()
+                .offset(x: Constants.badgeImageOffset)
+                .padding(.trailing, Constants.badgeImageOffset)
+        }
     }
 }
 

--- a/ARK Rate/Sources/Core/Presentation/Components/CurrencyCalculationRowView.swift
+++ b/ARK Rate/Sources/Core/Presentation/Components/CurrencyCalculationRowView.swift
@@ -4,9 +4,9 @@ struct CurrencyCalculationRowView: View {
 
     // MARK: - Properties
 
-    let from: CurrencyDisplayModel
-    let to: [CurrencyDisplayModel]
-    let refreshTime: String
+    let input: CurrencyDisplayModel
+    let outputs: [CurrencyDisplayModel]
+    let elapsedTime: String
     let action: ButtonAction
 
     @State private var isExpanded: Bool = false
@@ -14,16 +14,16 @@ struct CurrencyCalculationRowView: View {
     // MARK: - Initialization
 
     init?(
-        from: CurrencyDisplayModel,
-        to: [CurrencyDisplayModel],
-        refreshTime: String,
+        input: CurrencyDisplayModel,
+        outputs: [CurrencyDisplayModel],
+        elapsedTime: String,
         action: @escaping ButtonAction
     ) {
-        guard !to.isEmpty else { return nil }
+        guard !outputs.isEmpty else { return nil }
 
-        self.from = from
-        self.to = to
-        self.refreshTime = refreshTime
+        self.input = input
+        self.outputs = outputs
+        self.elapsedTime = elapsedTime
         self.action = action
     }
 
@@ -56,15 +56,15 @@ private extension CurrencyCalculationRowView {
 
     var badge: some View {
         ZStack(alignment: .leading) {
-            makeImage(code: from.id, size: Constants.badgeImageSize)
+            makeImage(code: input.id, size: Constants.badgeImageSize)
             additionalBadgeContent {
                 if isGroup {
-                    Text("\(to.count - 1)+")
+                    Text("\(outputs.count - 1)+")
                         .foregroundColor(Color.textTertiary)
                         .font(Font.customInterSemiBold(size: 16))
                         .frame(width: Constants.badgeImageSize, height: Constants.badgeImageSize)
                         .modifier(CircleBorderModifier())
-                } else if let to = to.first {
+                } else if let to = outputs.first {
                     makeImage(code: to.id, size: Constants.badgeImageSize)
                 }
             }
@@ -80,7 +80,7 @@ private extension CurrencyCalculationRowView {
                 .foregroundColor(Color.textTertiary)
                 .font(Font.customInterRegular(size: 14))
             if isExpanded {
-                ForEach(to, id: \.id) { currency in
+                ForEach(outputs, id: \.id) { currency in
                     HStack(spacing: 8) {
                         makeImage(code: currency.id, size: Constants.currencyImageSize)
                         Text(currency.formattedAmount)
@@ -89,7 +89,7 @@ private extension CurrencyCalculationRowView {
                     }
                 }
             }
-            Text(refreshTime)
+            Text(elapsedTime)
                 .foregroundColor(Color.textTertiary)
                 .font(Font.customInterRegular(size: 12))
         }
@@ -133,20 +133,20 @@ private extension CurrencyCalculationRowView {
 private extension CurrencyCalculationRowView {
 
     var isGroup: Bool {
-        to.count > 1
+        outputs.count > 1
     }
 
     var title: String {
         let take = 2
-        let ids = to.map(\.id)
+        let ids = outputs.map(\.id)
         let prefixIds = ids.prefix(take).joined(separator: ", ")
-        let remaining = to.count > take ? ", \(StringResource.and.localized) \(to.count - take)+" : ""
-        return "\(from.id) \(StringResource.to.localized.lowercased()) \(prefixIds)\(remaining)"
+        let remaining = outputs.count > take ? ", \(StringResource.and.localized) \(outputs.count - take)+" : ""
+        return "\(input.id) \(StringResource.to.localized.lowercased()) \(prefixIds)\(remaining)"
     }
 
     var subtitle: String {
-        let remaining = isExpanded ? "" : "\(to.first?.formattedAmount ?? "")"
-        return "\(from.formattedAmount) = \(remaining)"
+        let remaining = isExpanded ? "" : "\(outputs.first?.formattedAmount ?? "")"
+        return "\(input.formattedAmount) = \(remaining)"
     }
 }
 

--- a/ARK Rate/Sources/Core/Presentation/Extensions/DateExtension.swift
+++ b/ARK Rate/Sources/Core/Presentation/Extensions/DateExtension.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension Date {
+
+    // MARK: - Properties
+
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd MMM yyyy"
+        return formatter
+    }()
+
+    var formattedElapsedTime: String {
+        let components = Calendar.current.dateComponents([.day, .hour, .minute, .second], from: self, to: Date())
+        if let days = components.day, days >= 4 {
+            return Date.formatter.string(from: self)
+        }
+        switch (
+            components.day ?? 0,
+            components.hour ?? 0,
+            components.minute ?? 0,
+            components.second ?? 0
+        ) {
+        case let (day, _, _, _) where day > 0:
+            return StringResource.day.localizedFormat(day)
+        case let (_, hour, _, _) where hour > 0:
+            return StringResource.hour.localizedFormat(hour)
+        case let (_, _, minute, _) where minute > 0:
+            return StringResource.minute.localizedFormat(minute)
+        default:
+            let seconds = components.second ?? 0
+            return StringResource.second.localizedFormat(seconds)
+        }
+    }
+}
+
+// MARK: - Constants
+
+private extension Date {
+
+    enum StringResource: String.LocalizationValue {
+        case day = "elapsed_day"
+        case hour = "elapsed_hour"
+        case minute = "elapsed_minute"
+        case second = "elapsed_second"
+
+        func localizedFormat(_ args: CVarArg...) -> String {
+            let format = String(localized: rawValue)
+            return String(format: format, arguments: args)
+        }
+    }
+}

--- a/ARK Rate/Sources/Features/Currencies/CurrenciesFeature.swift
+++ b/ARK Rate/Sources/Features/Currencies/CurrenciesFeature.swift
@@ -8,7 +8,7 @@ struct CurrenciesFeature {
 
     enum Action {
         case fetchCurrencies
-        case currenciesUpdated([CurrencyDisplayModel])
+        case currenciesUpdated([Currency])
     }
 
     // MARK: - Properties
@@ -32,7 +32,6 @@ private extension CurrenciesFeature {
     func fetchCurrencies(_ state: inout State) -> Effect<Action> {
         Effect.run { send in
             for await currencies in fetchCurrenciesUseCase.execute() {
-                let currencies = currencies.map { CurrencyDisplayModel(from: $0) }
                 await send(Action.currenciesUpdated(currencies))
             }
         }

--- a/ARK Rate/Sources/Features/Currencies/CurrencyDisplayModel.swift
+++ b/ARK Rate/Sources/Features/Currencies/CurrencyDisplayModel.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct CurrencyDisplayModel: Identifiable, Equatable {
 
     // MARK: - Properties
@@ -17,7 +19,7 @@ struct CurrencyDisplayModel: Identifiable, Equatable {
 
     init(
         from currency: Currency,
-        amount: String = "0"
+        amount: String = ""
     ) {
         self.id = currency.code
         self.amount = amount

--- a/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
@@ -175,7 +175,7 @@ private extension AddQuickCalculationFeature {
             outputCurrencies: outputCurrencies
         )
         for (index, currency) in state.outputCurrencies.enumerated() {
-            state.outputCurrencies[index].amount = currencyAmounts[currency.code]?.formattedRate ?? ""
+            state.outputCurrencies[index].amount = currencyAmounts[currency.code] ?? ""
         }
     }
 

--- a/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
@@ -163,8 +163,8 @@ private extension AddQuickCalculationFeature {
 
     func updateOutputCurrenciesAmount(_ state: inout State) {
         guard let inputCurrencyAmount = Decimal(string: state.inputCurrency.amount),
-        let inputCurrency = state.currencies.first(where: { $0.code == state.inputCurrency.code }),
-        !state.outputCurrencies.isEmpty else { return }
+              let inputCurrency = state.currencies.first(where: { $0.code == state.inputCurrency.code }),
+              !state.outputCurrencies.isEmpty else { return }
         let outputCurrencies = state.currencies.filter { currency in
             state.outputCurrencies.contains(where: { $0.code == currency.code })
         }

--- a/ARK Rate/Sources/Features/Quick/QuickCalculationDisplayModel.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickCalculationDisplayModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct QuickCalculationDisplayModel: Equatable {
+
+    // MARK: - Properties
+
+    let id: UUID
+    let elapsedTime: String
+    let input: CurrencyDisplayModel
+    let outputs: [CurrencyDisplayModel]
+
+    // MARK: - Initialization
+
+    init(
+        id: UUID,
+        calculatedDate: Date,
+        input: CurrencyDisplayModel,
+        outputs: [CurrencyDisplayModel]
+    ) {
+        self.id = id
+        self.elapsedTime = calculatedDate.formattedElapsedTime
+        self.input = input
+        self.outputs = outputs
+    }
+}

--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -46,17 +46,17 @@ private extension QuickView {
     }
 
     var list: some View {
-        List {
-            calculationsSection
+        ZStack(alignment: .bottomTrailing) {
+            List {
+                calculationsSection
+            }
+            .listStyle(.plain)
+            addButton
         }
-        .listStyle(.plain)
     }
 
     var calculationsSection: some View {
-        Section(header: Text(StringResource.calculations.localized)
-            .foregroundColor(Color.textTertiary)
-            .font(Font.customInterMedium(size: 14))
-        ) {
+        makeListSection(title: StringResource.calculations.localized) {
             ForEach(store.quickCalculations, id: \.id) { calculation in
                 CurrencyCalculationRowView(
                     input: calculation.input,
@@ -67,6 +67,34 @@ private extension QuickView {
                 .listRowInsets(EdgeInsets())
                 .listRowSeparator(.hidden)
             }
+        }
+    }
+
+    var addButton: some View {
+        Button(
+            action: { store.send(.addNewCalculationButtonTapped) },
+            label: {
+                Image.plus
+                    .foregroundColor(Color.white)
+                    .font(Font.customInterBold(size: 24))
+                    .frame(width: 56, height: 56)
+                    .modifier(CircleBorderModifier(color: Color.teal700, backgroundColor: Color.teal600))
+                    .padding(16)
+            }
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private extension QuickView {
+
+    func makeListSection<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        Section(header: Text(title)
+            .foregroundColor(Color.textTertiary)
+            .font(Font.customInterMedium(size: 14))
+        ) {
+            content()
         }
     }
 }

--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -11,11 +11,7 @@ struct QuickView: View {
 
     var body: some View {
         NavigationStack {
-            VStack {
-                CalculationEmptyStateView {
-                    store.send(.addNewCalculationButtonTapped)
-                }
-            }
+            content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.backgroundPrimary)
             .navigationDestination(
@@ -30,15 +26,67 @@ struct QuickView: View {
     }
 }
 
+// MARK: -
+
+private extension QuickView {
+
+    @ViewBuilder
+    var content: some View {
+        if store.quickCalculations.isEmpty {
+            emptyStateView
+        } else {
+            list
+        }
+    }
+
+    var emptyStateView: some View {
+        CalculationEmptyStateView {
+            store.send(.addNewCalculationButtonTapped)
+        }
+    }
+
+    var list: some View {
+        List {
+            calculationsSection
+        }
+        .listStyle(.plain)
+    }
+
+    var calculationsSection: some View {
+        Section(header: Text(StringResource.calculations.localized)
+            .foregroundColor(Color.textTertiary)
+            .font(Font.customInterMedium(size: 14))
+        ) {
+            ForEach(store.quickCalculations, id: \.id) { calculation in
+                CurrencyCalculationRowView(
+                    input: calculation.input,
+                    outputs: calculation.outputs,
+                    elapsedTime: StringResource.calculatedOnAgo.localizedFormat(calculation.elapsedTime),
+                    action: {}
+                )
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+            }
+        }
+    }
+}
+
 // MARK: - Constants
 
 private extension QuickView {
 
     enum StringResource: String.LocalizationValue {
         case title = "quick_title"
+        case calculations
+        case calculatedOnAgo = "calculated_on_ago"
 
         var localized: String {
             String(localized: rawValue)
+        }
+
+        func localizedFormat(_ args: CVarArg...) -> String {
+            let format = String(localized: rawValue)
+            return String(format: format, arguments: args)
         }
     }
 }

--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -20,7 +20,7 @@ struct QuickView: View {
                 AddQuickCalculationView(store: store)
             }
             .onAppear {
-                store.send(.loadQuickCalculations)
+                store.send(.loadCurrencies)
             }
         }
     }


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
[Quick] Add Calculations section to Quick screen

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Add Calculations section to Quick screen
- Add floating "Create Calculations button" to Quick Screen

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| Light Mode | Dark Mode |
|------------|------------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-04-06 at 13 41 40](https://github.com/user-attachments/assets/6544e7ad-e946-4f5b-a3fd-d4dc2ab93c10) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-06 at 13 41 50](https://github.com/user-attachments/assets/ff5fac3a-a101-4cc1-a0b9-359bce77e1c1) |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[[Quick] Add Calculations section to Quick screen](https://app.asana.com/0/0/1209638463619215/f)