### PR TITLE
[Quick] Add All currencies section to Quick screen

### DIFF
--- a/ARK Rate/Sources/Core/Presentation/Modifiers/PlainListRowModifier.swift
+++ b/ARK Rate/Sources/Core/Presentation/Modifiers/PlainListRowModifier.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct PlainListRowModifier: ViewModifier {
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        content
+            .listRowInsets(EdgeInsets())
+            .listRowSeparator(.hidden)
+    }
+}

--- a/ARK Rate/Sources/Features/Quick/QuickFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickFeature.swift
@@ -7,6 +7,7 @@ struct QuickFeature {
     struct State: Equatable {
         @Presents var destination: Destination.State?
         var currencies: [Currency] = []
+        var displayingCurrencies: [CurrencyDisplayModel] = []
         var quickCalculations: [QuickCalculationDisplayModel] = []
     }
 
@@ -49,6 +50,7 @@ private extension QuickFeature {
 
     func currenciesUpdated(_ state: inout State, _ currencies: [Currency]) -> Effect<Action> {
         state.currencies = currencies
+        state.displayingCurrencies = currencies.map { CurrencyDisplayModel(from: $0) }
         return .send(.loadQuickCalculations)
     }
 
@@ -62,8 +64,7 @@ private extension QuickFeature {
         do {
             currencies = try currencyRepository.getLocal()
         } catch {}
-        state.currencies = currencies
-        return .send(.loadQuickCalculations)
+        return currenciesUpdated(&state, currencies)
     }
 
     func loadQuickCalculations(_ state: inout State) -> Effect<Action> {

--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -49,6 +49,7 @@ private extension QuickView {
         ZStack(alignment: .bottomTrailing) {
             List {
                 calculationsSection
+                allCurrenciesSection
             }
             .listStyle(.plain)
             addButton
@@ -64,8 +65,20 @@ private extension QuickView {
                     elapsedTime: StringResource.calculatedOnAgo.localizedFormat(calculation.elapsedTime),
                     action: {}
                 )
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
+                .modifier(PlainListRowModifier())
+            }
+        }
+    }
+
+    var allCurrenciesSection: some View {
+        makeListSection(title: StringResource.allCurrencies.localized) {
+            ForEach(store.displayingCurrencies, id: \.id) { currency in
+                CurrencyRowView(
+                    code: currency.id,
+                    name: currency.name,
+                    action: {}
+                )
+                .modifier(PlainListRowModifier())
             }
         }
     }
@@ -107,6 +120,7 @@ private extension QuickView {
         case title = "quick_title"
         case calculations
         case calculatedOnAgo = "calculated_on_ago"
+        case allCurrencies = "all_currencies"
 
         var localized: String {
             String(localized: rawValue)

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
@@ -59,8 +59,7 @@ private extension SearchACurrencyView {
                     name: currency.name,
                     action: { store.send(.currencyCodeSelected(currency.id)) }
                 )
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
+                .modifier(PlainListRowModifier())
             }
         }
     }


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
[Quick] Add All currencies section to Quick screen

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Add All currencies section to Quick screen

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| Light Mode | Dark Mode |
|------------|------------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-04-06 at 14 29 17](https://github.com/user-attachments/assets/e3ed987f-8214-4e28-a0d7-76285d9cacc8) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-06 at 14 25 05](https://github.com/user-attachments/assets/06f78a23-1680-4730-84f2-a1fefe01773b) |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[[Quick] Add All currencies section to Quick screen](https://app.asana.com/0/0/1209638463619220/f)