### PR TITLE
[Quick] Add Frequent currencies to Search a currency screen

### DIFF
--- a/ARK Rate/Sources/App/ARKRateApp.swift
+++ b/ARK Rate/Sources/App/ARKRateApp.swift
@@ -15,6 +15,7 @@ struct ARKRateApp: App {
     private var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             CurrencyModel.self,
+            CurrencyStatisticModel.self,
             QuickCalculationModel.self
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)

--- a/ARK Rate/Sources/App/AppDependencies.swift
+++ b/ARK Rate/Sources/App/AppDependencies.swift
@@ -7,6 +7,11 @@ extension DependencyValues {
         set { self[FetchCurrenciesUseCaseKey.self] = newValue }
     }
 
+    var getFrequentCurrenciesUseCase: GetFrequentCurrenciesUseCase {
+        get { self[GetFrequentCurrenciesUseCaseKey.self] }
+        set { self[GetFrequentCurrenciesUseCaseKey.self] = newValue }
+    }
+
     var currencyCalculationUseCase: CurrencyCalculationUseCase {
         get { self[CurrencyCalculationUseCaseKey.self] }
         set { self[CurrencyCalculationUseCaseKey.self] = newValue }
@@ -58,6 +63,16 @@ extension DependencyValues {
 private enum FetchCurrenciesUseCaseKey: DependencyKey {
 
     static let liveValue: FetchCurrenciesUseCase = FetchCurrenciesUseCase(currencyRepository: DependencyValues._current.currencyRepository)
+}
+
+// MARK: - GetFrequentCurrenciesUseCase
+
+private enum GetFrequentCurrenciesUseCaseKey: DependencyKey {
+
+    static let liveValue: GetFrequentCurrenciesUseCase = GetFrequentCurrenciesUseCase(
+        currencyRepository: DependencyValues._current.currencyRepository,
+        currencyStatisticRepository: DependencyValues._current.currencyStatisticRepository
+    )
 }
 
 // MARK: - CurrencyCalculationUseCase

--- a/ARK Rate/Sources/App/AppDependencies.swift
+++ b/ARK Rate/Sources/App/AppDependencies.swift
@@ -2,14 +2,14 @@ import ComposableArchitecture
 
 extension DependencyValues {
 
-    var fetchCurrenciesUseCase: FetchCurrenciesUseCase {
-        get { self[FetchCurrenciesUseCaseKey.self] }
-        set { self[FetchCurrenciesUseCaseKey.self] = newValue }
+    var loadCurrenciesUseCase: LoadCurrenciesUseCase {
+        get { self[LoadCurrenciesUseCaseKey.self] }
+        set { self[LoadCurrenciesUseCaseKey.self] = newValue }
     }
 
-    var getFrequentCurrenciesUseCase: GetFrequentCurrenciesUseCase {
-        get { self[GetFrequentCurrenciesUseCaseKey.self] }
-        set { self[GetFrequentCurrenciesUseCaseKey.self] = newValue }
+    var loadFrequentCurrenciesUseCase: LoadFrequentCurrenciesUseCase {
+        get { self[LoadFrequentCurrenciesUseCaseKey.self] }
+        set { self[LoadFrequentCurrenciesUseCaseKey.self] = newValue }
     }
 
     var currencyCalculationUseCase: CurrencyCalculationUseCase {
@@ -58,18 +58,18 @@ extension DependencyValues {
     }
 }
 
-// MARK: - FetchCurrenciesUseCase
+// MARK: - LoadCurrenciesUseCase
 
-private enum FetchCurrenciesUseCaseKey: DependencyKey {
+private enum LoadCurrenciesUseCaseKey: DependencyKey {
 
-    static let liveValue: FetchCurrenciesUseCase = FetchCurrenciesUseCase(currencyRepository: DependencyValues._current.currencyRepository)
+    static let liveValue: LoadCurrenciesUseCase = LoadCurrenciesUseCase(currencyRepository: DependencyValues._current.currencyRepository)
 }
 
-// MARK: - GetFrequentCurrenciesUseCase
+// MARK: - LoadFrequentCurrenciesUseCase
 
-private enum GetFrequentCurrenciesUseCaseKey: DependencyKey {
+private enum LoadFrequentCurrenciesUseCaseKey: DependencyKey {
 
-    static let liveValue: GetFrequentCurrenciesUseCase = GetFrequentCurrenciesUseCase(
+    static let liveValue: LoadFrequentCurrenciesUseCase = LoadFrequentCurrenciesUseCase(
         currencyRepository: DependencyValues._current.currencyRepository,
         currencyStatisticRepository: DependencyValues._current.currencyStatisticRepository
     )

--- a/ARK Rate/Sources/App/AppDependencies.swift
+++ b/ARK Rate/Sources/App/AppDependencies.swift
@@ -17,6 +17,11 @@ extension DependencyValues {
         set { self[CurrencyRepositoryKey.self] = newValue }
     }
 
+    var currencyStatisticRepository: CurrencyStatisticRepository {
+        get { self[CurrencyStatisticRepositoryKey.self] }
+        set { self[CurrencyStatisticRepositoryKey.self] = newValue }
+    }
+
     var quickCalculationRepository: QuickCalculationRepository {
         get { self[QuickCalculationRepositoryKey.self] }
         set { self[QuickCalculationRepositoryKey.self] = newValue }
@@ -35,6 +40,11 @@ extension DependencyValues {
     var currencyLocalDataSource: CurrencyLocalDataSource {
         get { self[CurrencyLocalDataSourceKey.self] }
         set { self[CurrencyLocalDataSourceKey.self] = newValue }
+    }
+
+    var currencyStatisticLocalDataSource: CurrencyStatisticLocalDataSource {
+        get { self[CurrencyStatisticLocalDataSourceKey.self] }
+        set { self[CurrencyStatisticLocalDataSourceKey.self] = newValue }
     }
 
     var quickCalculationLocalDataSource: QuickCalculationLocalDataSource {
@@ -82,6 +92,15 @@ private enum QuickCalculationRepositoryKey: DependencyKey {
     )
 }
 
+// MARK: - CurrencyStatisticRepository
+
+private enum CurrencyStatisticRepositoryKey: DependencyKey {
+
+    static let liveValue: CurrencyStatisticRepository = CurrencyStatisticRepositoryImpl(
+        localDataSource: DependencyValues._current.currencyStatisticLocalDataSource
+    )
+}
+
 // MARK: - FiatCurrenciesRateAPI
 
 private enum FiatCurrenciesRateAPIKey: DependencyKey {
@@ -101,6 +120,13 @@ private enum CryptoCurrenciesRateAPIKey: DependencyKey {
 private enum CurrencyLocalDataSourceKey: DependencyKey {
 
     static let liveValue: CurrencyLocalDataSource = CurrencySwiftDataDataSource()
+}
+
+// MARK: - CurrencyStatisticLocalDataSource
+
+private enum CurrencyStatisticLocalDataSourceKey: DependencyKey {
+
+    static let liveValue: CurrencyStatisticLocalDataSource = CurrencyStatisticSwiftDataDataSource()
 }
 
 // MARK: - QuickCalculationLocalDataSource

--- a/ARK Rate/Sources/App/AppDependencies.swift
+++ b/ARK Rate/Sources/App/AppDependencies.swift
@@ -77,7 +77,9 @@ private enum CurrencyRepositoryKey: DependencyKey {
 
 private enum QuickCalculationRepositoryKey: DependencyKey {
 
-    static let liveValue: QuickCalculationRepository = QuickCalculationRepositoryImpl(localDataSource: DependencyValues._current.quickCalculationLocalDataSource)
+    static let liveValue: QuickCalculationRepository = QuickCalculationRepositoryImpl(
+        localDataSource: DependencyValues._current.quickCalculationLocalDataSource
+    )
 }
 
 // MARK: - FiatCurrenciesRateAPI

--- a/ARK Rate/Sources/Core/Data/DTO/CurrencyStatisticDTO.swift
+++ b/ARK Rate/Sources/Core/Data/DTO/CurrencyStatisticDTO.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct CurrencyStatisticDTO {
+
+    // MARK: - Properties
+
+    let code: String
+    let usageCount: UInt
+    let lastUsedDate: Date
+}

--- a/ARK Rate/Sources/Core/Data/DataSources/CurrencyLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/CurrencyLocalDataSource.swift
@@ -1,5 +1,12 @@
 protocol CurrencyLocalDataSource {
 
-    func get() throws -> [CurrencyDTO]
+    func get(where codes: [String]?) throws -> [CurrencyDTO]
     func save(_ currencies: [CurrencyDTO]) throws
+}
+
+extension CurrencyLocalDataSource {
+
+    func get(where codes: [String]? = nil) throws -> [CurrencyDTO] {
+        try get(where: codes)
+    }
 }

--- a/ARK Rate/Sources/Core/Data/DataSources/CurrencyLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/CurrencyLocalDataSource.swift
@@ -6,7 +6,7 @@ protocol CurrencyLocalDataSource {
 
 extension CurrencyLocalDataSource {
 
-    func get(where codes: [String]? = nil) throws -> [CurrencyDTO] {
-        try get(where: codes)
+    func get() throws -> [CurrencyDTO] {
+        try get(where: nil)
     }
 }

--- a/ARK Rate/Sources/Core/Data/DataSources/CurrencyStatisticLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/CurrencyStatisticLocalDataSource.swift
@@ -1,0 +1,5 @@
+protocol CurrencyStatisticLocalDataSource {
+
+    func get(limit: Int) throws -> [CurrencyStatisticDTO]
+    func save(_ currencyStatistics: [CurrencyStatisticDTO]) throws
+}

--- a/ARK Rate/Sources/Core/Data/DataSources/CurrencyStatisticLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/CurrencyStatisticLocalDataSource.swift
@@ -1,5 +1,5 @@
 protocol CurrencyStatisticLocalDataSource {
 
-    func get(limit: Int) throws -> [CurrencyStatisticDTO]
+    func get() throws -> [CurrencyStatisticDTO]
     func save(_ currencyStatistics: [CurrencyStatisticDTO]) throws
 }

--- a/ARK Rate/Sources/Core/Data/Local/CurrencyStatisticSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/CurrencyStatisticSwiftDataDataSource.swift
@@ -4,8 +4,8 @@ struct CurrencyStatisticSwiftDataDataSource: CurrencyStatisticLocalDataSource {
 
     // MARK: - Conformance
 
-    func get(limit: Int) throws -> [CurrencyStatisticDTO] {
-        let models: [CurrencyStatisticModel] = try SwiftDataManager.shared.get(limit: limit)
+    func get() throws -> [CurrencyStatisticDTO] {
+        let models: [CurrencyStatisticModel] = try SwiftDataManager.shared.get()
         return models.map(\.toCurrencyStatisticDTO)
     }
 

--- a/ARK Rate/Sources/Core/Data/Local/CurrencyStatisticSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/CurrencyStatisticSwiftDataDataSource.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct CurrencyStatisticSwiftDataDataSource: CurrencyStatisticLocalDataSource {
+
+    // MARK: - Conformance
+
+    func get(limit: Int) throws -> [CurrencyStatisticDTO] {
+        let models: [CurrencyStatisticModel] = try SwiftDataManager.shared.get(limit: limit)
+        return models.map(\.toCurrencyStatisticDTO)
+    }
+
+    func save(_ currencyStatistics: [CurrencyStatisticDTO]) throws {
+        let codes = Set(currencyStatistics.map(\.code))
+        let models = currencyStatistics.map(\.toCurrencyStatisticModel)
+        let fetchedModels: [CurrencyStatisticModel] = try SwiftDataManager.shared.get(predicate: #Predicate { codes.contains($0.code) })
+        let fetchedModelsMap = Dictionary(uniqueKeysWithValues: fetchedModels.map { ($0.code, $0) })
+        for model in models {
+            if let fetchedModel = fetchedModelsMap[model.code] {
+                fetchedModel.usageCount += 1
+                fetchedModel.lastUsedDate = model.lastUsedDate
+            } else {
+                try SwiftDataManager.shared.insert(model, commit: false)
+            }
+        }
+        try SwiftDataManager.shared.save()
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
@@ -1,16 +1,26 @@
-import SwiftData
+import Foundation
 
 struct CurrencySwiftDataDataSource: CurrencyLocalDataSource {
 
     // MARK: - Conformance
 
     func get() throws -> [CurrencyDTO] {
-        let models = try SwiftDataManager.shared.get(CurrencyModel.self)
-        return models.map { $0.toCurrencyDTO }
+        let models: [CurrencyModel] = try SwiftDataManager.shared.get()
+        return models.map(\.toCurrencyDTO)
     }
 
     func save(_ currencies: [CurrencyDTO]) throws {
-        let models = currencies.map { $0.toCurrencyModel }
-        try SwiftDataManager.shared.insertOrUpdate(models)
+        let codes = Set(currencies.map(\.code))
+        let models = currencies.map(\.toCurrencyModel)
+        let fetchedModels: [CurrencyModel] = try SwiftDataManager.shared.get(predicate: #Predicate { codes.contains($0.code) })
+        let fetchedModelsMap = Dictionary(uniqueKeysWithValues: fetchedModels.map { ($0.code, $0) })
+        for model in models {
+            if let fetchedModel = fetchedModelsMap[model.code] {
+                fetchedModel.rate = model.rate
+            } else {
+                try SwiftDataManager.shared.insert(model, commit: false)
+            }
+        }
+        try SwiftDataManager.shared.save()
     }
 }

--- a/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
@@ -4,9 +4,16 @@ struct CurrencySwiftDataDataSource: CurrencyLocalDataSource {
 
     // MARK: - Conformance
 
-    func get() throws -> [CurrencyDTO] {
-        let models: [CurrencyModel] = try SwiftDataManager.shared.get()
-        return models.map(\.toCurrencyDTO)
+    func get(where codes: [String]?) throws -> [CurrencyDTO] {
+        let predicate: Predicate<CurrencyModel>? = {
+            if let codes {
+                return #Predicate { codes.contains($0.code) }
+            } else {
+                return nil
+            }
+        }()
+        let fetchedModels: [CurrencyModel] = try SwiftDataManager.shared.get(predicate: predicate)
+        return fetchedModels.map(\.toCurrencyDTO)
     }
 
     func save(_ currencies: [CurrencyDTO]) throws {

--- a/ARK Rate/Sources/Core/Data/Local/Models/CurrencyStatisticModel.swift
+++ b/ARK Rate/Sources/Core/Data/Local/Models/CurrencyStatisticModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CurrencyStatisticModel {
+
+    // MARK: - Properties
+
+    @Attribute(.unique) var code: String
+    var usageCount: UInt
+    var lastUsedDate: Date
+
+    // MARK: - Initialization
+
+    init(code: String, usageCount: UInt, lastUsedDate: Date) {
+        self.code = code
+        self.usageCount = usageCount
+        self.lastUsedDate = lastUsedDate
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
@@ -5,12 +5,12 @@ struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
     // MARK: - Conformance
 
     func get() throws -> [QuickCalculationDTO] {
-        let models = try SwiftDataManager.shared.get(QuickCalculationModel.self)
-        return models.map { $0.toQuickCalculationDTO }
+        let models: [QuickCalculationModel] = try SwiftDataManager.shared.get()
+        return models.map(\.toQuickCalculationDTO)
     }
 
     func save(_ calculation: QuickCalculationDTO) throws {
         let model = calculation.toQuickCalculationModel
-        try SwiftDataManager.shared.insertOrUpdate(model)
+        try SwiftDataManager.shared.insert(model)
     }
 }

--- a/ARK Rate/Sources/Core/Data/Local/SwiftDataManager.swift
+++ b/ARK Rate/Sources/Core/Data/Local/SwiftDataManager.swift
@@ -7,38 +7,32 @@ final class SwiftDataManager {
 
     static let shared = SwiftDataManager()
 
-    var modelContext: ModelContext?
+    var modelContext: ModelContext!
 
     // MARK: - Methods
 
-    func insertOrUpdate(_ models: [CurrencyModel]) throws {
-        guard let modelContext else { return }
-
-        let ids = Set(models.map { $0.code })
-        let fetchDescriptor = FetchDescriptor<CurrencyModel>(predicate: #Predicate { ids.contains($0.code) })
-        let fetchedModels = try modelContext.fetch(fetchDescriptor)
-        let fetchedModelsMap = Dictionary(uniqueKeysWithValues: fetchedModels.map { ($0.code, $0) })
-
-        models.forEach { model in
-            if let fetchedModel = fetchedModelsMap[model.code] {
-                fetchedModel.rate = model.rate
-            } else {
-                modelContext.insert(model)
-            }
-        }
-        try modelContext.save()
-    }
-
-    func insertOrUpdate(_ model: QuickCalculationModel) throws {
-        guard let modelContext else { return }
-
-        modelContext.insert(model)
-        try modelContext.save()
-    }
-
-    func get<T: PersistentModel>(_ type: T.Type) throws -> [T] {
-        guard let modelContext else { return [] }
-        let fetchDescriptor = FetchDescriptor<T>()
+    func get<T: PersistentModel>(predicate: Predicate<T>? = nil, limit: Int? = nil) throws -> [T] {
+        var fetchDescriptor = FetchDescriptor<T>(predicate: predicate)
+        fetchDescriptor.fetchLimit = limit
         return try modelContext.fetch(fetchDescriptor)
+    }
+
+    func get<T: PersistentModel>(predicate: Predicate<T>? = nil) throws -> T? {
+        try get(predicate: predicate, limit: 1).first
+    }
+
+    func insert<T: PersistentModel>(_ model: T, commit: Bool = true) throws {
+        modelContext.insert(model)
+        if commit { try save() }
+    }
+
+    func insert<T: PersistentModel>(_ models: [T], commit: Bool = true) throws {
+        for model in models {
+            try insert(model, commit: commit)
+        }
+    }
+
+    func save() throws {
+        try modelContext.save()
     }
 }

--- a/ARK Rate/Sources/Core/Data/Mappers/CurrencyStatisticMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/CurrencyStatisticMapper.swift
@@ -1,0 +1,46 @@
+// MARK: -
+
+extension CurrencyStatistic {
+
+    var toCurrencyStatisticDTO: CurrencyStatisticDTO {
+        CurrencyStatisticDTO(
+            code: code,
+            usageCount: usageCount,
+            lastUsedDate: lastUsedDate
+        )
+    }
+}
+
+// MARK: -
+
+extension CurrencyStatisticDTO {
+
+    var toCurrencyStatistic: CurrencyStatistic {
+        CurrencyStatistic(
+            code: code,
+            usageCount: usageCount,
+            lastUsedDate: lastUsedDate
+        )
+    }
+
+    var toCurrencyStatisticModel: CurrencyStatisticModel {
+        CurrencyStatisticModel(
+            code: code,
+            usageCount: usageCount,
+            lastUsedDate: lastUsedDate
+        )
+    }
+}
+
+// MARK: -
+
+extension CurrencyStatisticModel {
+
+    var toCurrencyStatisticDTO: CurrencyStatisticDTO {
+        CurrencyStatisticDTO(
+            code: code,
+            usageCount: usageCount,
+            lastUsedDate: lastUsedDate
+        )
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -12,8 +12,12 @@ extension QuickCalculation {
         )
     }
 
+    var toCodes: [String] {
+        ([inputCurrencyCode] + outputCurrenciesCode)
+    }
+
     var toCurrencyStatistics: [CurrencyStatistic] {
-        ([inputCurrencyCode] + outputCurrenciesCode).map { CurrencyStatistic(code: $0) }
+        toCodes.map { CurrencyStatistic(code: $0) }
     }
 }
 

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -11,6 +11,10 @@ extension QuickCalculation {
             outputCurrenciesCode: outputCurrenciesCode
         )
     }
+
+    var toCurrencyStatistics: [CurrencyStatistic] {
+        ([inputCurrencyCode] + outputCurrenciesCode).map { CurrencyStatistic(code: $0) }
+    }
 }
 
 // MARK: -

--- a/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
@@ -20,8 +20,8 @@ final class CurrencyRepositoryImpl: CurrencyRepository {
 
     // MARK: - Conformance
 
-    func getLocal() throws -> [Currency] {
-        try localDataSource.get().map(\.toCurrency)
+    func getLocal(where codes: [String]?) throws -> [Currency] {
+        try localDataSource.get(where: codes).map(\.toCurrency)
     }
 
     func fetchRemote() async throws -> [Currency] {

--- a/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
@@ -21,9 +21,7 @@ final class CurrencyRepositoryImpl: CurrencyRepository {
     // MARK: - Conformance
 
     func getLocal() throws -> [Currency] {
-        try localDataSource.get()
-            .map { $0.toCurrency }
-            .sorted { $0.code < $1.code }
+        try localDataSource.get().map(\.toCurrency)
     }
 
     func fetchRemote() async throws -> [Currency] {
@@ -36,8 +34,6 @@ final class CurrencyRepositoryImpl: CurrencyRepository {
         let fiatFilteredCurrencies = fiatCurrencies.filter { !fiatDuplicateCodes.contains($0.code) }
         let currencies = fiatFilteredCurrencies + cryptoCurrencies
         try localDataSource.save(currencies)
-        return currencies
-            .map { $0.toCurrency }
-            .sorted { $0.code < $1.code }
+        return currencies.map(\.toCurrency)
     }
 }

--- a/ARK Rate/Sources/Core/Data/Repositories/CurrencyStatisticRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/CurrencyStatisticRepositoryImpl.swift
@@ -12,8 +12,8 @@ final class CurrencyStatisticRepositoryImpl: CurrencyStatisticRepository {
 
     // MARK: - Conformance
 
-    func get(limit: Int) throws -> [CurrencyStatistic] {
-        try localDataSource.get(limit: limit)
+    func get() throws -> [CurrencyStatistic] {
+        try localDataSource.get()
             .map(\.toCurrencyStatistic)
     }
 

--- a/ARK Rate/Sources/Core/Data/Repositories/CurrencyStatisticRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/CurrencyStatisticRepositoryImpl.swift
@@ -13,8 +13,7 @@ final class CurrencyStatisticRepositoryImpl: CurrencyStatisticRepository {
     // MARK: - Conformance
 
     func get() throws -> [CurrencyStatistic] {
-        try localDataSource.get()
-            .map(\.toCurrencyStatistic)
+        try localDataSource.get().map(\.toCurrencyStatistic)
     }
 
     func save(_ currencyStatistics: [CurrencyStatistic]) throws {

--- a/ARK Rate/Sources/Core/Data/Repositories/CurrencyStatisticRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/CurrencyStatisticRepositoryImpl.swift
@@ -1,0 +1,25 @@
+final class CurrencyStatisticRepositoryImpl: CurrencyStatisticRepository {
+
+    // MARK: - Properties
+
+    private let localDataSource: CurrencyStatisticLocalDataSource
+
+    // MARK: - Initialization
+
+    init(localDataSource: CurrencyStatisticLocalDataSource) {
+        self.localDataSource = localDataSource
+    }
+
+    // MARK: - Conformance
+
+    func get(limit: Int) throws -> [CurrencyStatistic] {
+        try localDataSource.get(limit: limit)
+            .map(\.toCurrencyStatistic)
+    }
+
+    func save(_ currencyStatistics: [CurrencyStatistic]) throws {
+        try localDataSource.save(
+            currencyStatistics.map(\.toCurrencyStatisticDTO)
+        )
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
@@ -18,6 +18,7 @@ final class QuickCalculationRepositoryImpl: QuickCalculationRepository {
 
     func get() throws -> [QuickCalculation] {
         try localDataSource.get()
-            .map { $0.toQuickCalculation }
+            .map(\.toQuickCalculation)
+            .sorted(by: { $0.calculatedDate > $1.calculatedDate })
     }
 }

--- a/ARK Rate/Sources/Core/Domain/Entities/CurrencyStatistic.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/CurrencyStatistic.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct CurrencyStatistic {
+
+    // MARK: - Properties
+
+    let code: String
+    let usageCount: UInt
+    let lastUsedDate: Date
+
+    // MARK: - Initialization
+
+    init(
+        code: String,
+        usageCount: UInt = 1,
+        lastUsedDate: Date = Date()
+    ) {
+        self.code = code
+        self.usageCount = usageCount
+        self.lastUsedDate = lastUsedDate
+    }
+}

--- a/ARK Rate/Sources/Core/Domain/Entities/CurrencyStatistic.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/CurrencyStatistic.swift
@@ -8,6 +8,12 @@ struct CurrencyStatistic {
     let usageCount: UInt
     let lastUsedDate: Date
 
+    var rating: Double {
+        let daysPassedSinceNow = lastUsedDate.daysPassedSinceNow
+        let timeFactor = Double(daysPassedSinceNow) * 0.5
+        return Double(usageCount) - timeFactor
+    }
+
     // MARK: - Initialization
 
     init(

--- a/ARK Rate/Sources/Core/Domain/Repositories/CurrencyRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/CurrencyRepository.swift
@@ -6,7 +6,7 @@ protocol CurrencyRepository {
 
 extension CurrencyRepository {
 
-    func getLocal(where codes: [String]? = nil) throws -> [Currency] {
-        try getLocal(where: codes)
+    func getLocal() throws -> [Currency] {
+        try getLocal(where: nil)
     }
 }

--- a/ARK Rate/Sources/Core/Domain/Repositories/CurrencyRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/CurrencyRepository.swift
@@ -1,5 +1,12 @@
 protocol CurrencyRepository {
 
-    func getLocal() throws -> [Currency]
+    func getLocal(where codes: [String]?) throws -> [Currency]
     func fetchRemote() async throws -> [Currency]
+}
+
+extension CurrencyRepository {
+
+    func getLocal(where codes: [String]? = nil) throws -> [Currency] {
+        try getLocal(where: codes)
+    }
 }

--- a/ARK Rate/Sources/Core/Domain/Repositories/CurrencyStatisticRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/CurrencyStatisticRepository.swift
@@ -1,0 +1,5 @@
+protocol CurrencyStatisticRepository {
+
+    func get(limit: Int) throws -> [CurrencyStatistic]
+    func save(_ currencyStatistics: [CurrencyStatistic]) throws
+}

--- a/ARK Rate/Sources/Core/Domain/Repositories/CurrencyStatisticRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/CurrencyStatisticRepository.swift
@@ -1,5 +1,5 @@
 protocol CurrencyStatisticRepository {
 
-    func get(limit: Int) throws -> [CurrencyStatistic]
+    func get() throws -> [CurrencyStatistic]
     func save(_ currencyStatistics: [CurrencyStatistic]) throws
 }

--- a/ARK Rate/Sources/Core/Domain/UseCases/GetFrequentCurrenciesUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/GetFrequentCurrenciesUseCase.swift
@@ -1,0 +1,31 @@
+struct GetFrequentCurrenciesUseCase {
+
+    // MARK: - Properties
+
+    let currencyRepository: CurrencyRepository
+    let currencyStatisticRepository: CurrencyStatisticRepository
+
+    // MARK: - Methods
+
+    func execute() -> [Currency] {
+        do {
+            let codes = try currencyStatisticRepository
+                .get()
+                .sorted(by: { $0.rating > $1.rating })
+                .prefix(Constants.limit)
+                .map(\.code)
+            return try currencyRepository.getLocal(where: codes)
+        } catch {
+            return []
+        }
+    }
+}
+
+// MARK: - Constants
+
+private extension GetFrequentCurrenciesUseCase {
+
+    enum Constants {
+        static let limit = 5
+    }
+}

--- a/ARK Rate/Sources/Core/Domain/UseCases/LoadCurrenciesUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/LoadCurrenciesUseCase.swift
@@ -1,4 +1,4 @@
-struct FetchCurrenciesUseCase {
+struct LoadCurrenciesUseCase {
 
     // MARK: - Properties
 
@@ -6,17 +6,23 @@ struct FetchCurrenciesUseCase {
 
     // MARK: - Methods
 
-    func execute() -> AsyncStream<[Currency]> {
+    func fetchRemote() -> AsyncStream<[Currency]> {
         AsyncStream { continuation in
             Task {
                 let localCurrencies = try currencyRepository.getLocal()
+                    .sorted { $0.code < $1.code }
                 continuation.yield(localCurrencies)
 
                 let remoteCurrencies = try await currencyRepository.fetchRemote()
+                    .sorted { $0.code < $1.code }
                 continuation.yield(remoteCurrencies)
 
                 continuation.finish()
             }
         }
+    }
+
+    func getLocal() -> [Currency] {
+        (try? currencyRepository.getLocal().sorted { $0.code < $1.code }) ?? []
     }
 }

--- a/ARK Rate/Sources/Core/Domain/UseCases/LoadFrequentCurrenciesUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/LoadFrequentCurrenciesUseCase.swift
@@ -1,4 +1,4 @@
-struct GetFrequentCurrenciesUseCase {
+struct LoadFrequentCurrenciesUseCase {
 
     // MARK: - Properties
 
@@ -23,7 +23,7 @@ struct GetFrequentCurrenciesUseCase {
 
 // MARK: - Constants
 
-private extension GetFrequentCurrenciesUseCase {
+private extension LoadFrequentCurrenciesUseCase {
 
     enum Constants {
         static let limit = 5

--- a/ARK Rate/Sources/Core/Presentation/Components/CurrencyInputView.swift
+++ b/ARK Rate/Sources/Core/Presentation/Components/CurrencyInputView.swift
@@ -89,8 +89,6 @@ private extension CurrencyInputView {
             }
             .frame(maxHeight: .infinity)
             .modifier(RoundedBorderModifier(color: Color.error))
-        } else {
-            EmptyView()
         }
     }
 }

--- a/ARK Rate/Sources/Core/Presentation/Components/ListSection.swift
+++ b/ARK Rate/Sources/Core/Presentation/Components/ListSection.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ListSection<Content: View>: View {
+
+    // MARK: - Properties
+
+    let title: String
+    @ViewBuilder let content: () -> Content
+
+    // MARK: - Body
+
+    var body: some View {
+        Section(
+            header: Text(title)
+                .foregroundColor(Color.textTertiary)
+                .font(Font.customInterMedium(size: 14))
+        ) {
+            content()
+        }
+    }
+}

--- a/ARK Rate/Sources/Core/Presentation/Extensions/DateExtension.swift
+++ b/ARK Rate/Sources/Core/Presentation/Extensions/DateExtension.swift
@@ -32,6 +32,10 @@ extension Date {
             return StringResource.second.localizedFormat(seconds)
         }
     }
+
+    var daysPassedSinceNow: Int {
+        Calendar.current.dateComponents([.day], from: self, to: Date()).day ?? 0
+    }
 }
 
 // MARK: - Constants

--- a/ARK Rate/Sources/Features/Currencies/CurrenciesFeature.swift
+++ b/ARK Rate/Sources/Features/Currencies/CurrenciesFeature.swift
@@ -13,7 +13,7 @@ struct CurrenciesFeature {
 
     // MARK: - Properties
 
-    @Dependency(\.fetchCurrenciesUseCase) var fetchCurrenciesUseCase
+    @Dependency(\.loadCurrenciesUseCase) var loadCurrenciesUseCase
 
     // MARK: - Reducer
 
@@ -31,8 +31,8 @@ private extension CurrenciesFeature {
 
     func fetchCurrencies(_ state: inout State) -> Effect<Action> {
         Effect.run { send in
-            for await currencies in fetchCurrenciesUseCase.execute() {
-                await send(Action.currenciesUpdated(currencies))
+            for await currencies in loadCurrenciesUseCase.fetchRemote() {
+                await send(.currenciesUpdated(currencies))
             }
         }
     }

--- a/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
@@ -43,6 +43,7 @@ struct AddQuickCalculationFeature {
     @Dependency(\.dismiss) var back
     @Dependency(\.currencyRepository) var currencyRepository
     @Dependency(\.quickCalculationRepository) var quickCalculationRepository
+    @Dependency(\.currencyStatisticRepository) var currencyStatisticRepository
     @Dependency(\.currencyCalculationUseCase) var currencyCalculationUseCase
 
     // MARK: - Reducer
@@ -148,6 +149,7 @@ private extension AddQuickCalculationFeature {
         if let quickCalculation = state.quickCalculation {
             do {
                 try quickCalculationRepository.save(quickCalculation)
+                try currencyStatisticRepository.save(quickCalculation.toCurrencyStatistics)
             } catch {}
         }
         return Effect.run { send in

--- a/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
@@ -41,9 +41,9 @@ struct AddQuickCalculationFeature {
     // MARK: - Properties
 
     @Dependency(\.dismiss) var back
-    @Dependency(\.currencyRepository) var currencyRepository
     @Dependency(\.quickCalculationRepository) var quickCalculationRepository
     @Dependency(\.currencyStatisticRepository) var currencyStatisticRepository
+    @Dependency(\.loadCurrenciesUseCase) var loadCurrenciesUseCase
     @Dependency(\.currencyCalculationUseCase) var currencyCalculationUseCase
 
     // MARK: - Reducer
@@ -80,11 +80,7 @@ private extension AddQuickCalculationFeature {
     }
 
     func loadCurrencies(_ state: inout State) -> Effect<Action> {
-        var currencies: [Currency] = []
-        do {
-            currencies = try currencyRepository.getLocal()
-        } catch {}
-        state.currencies = currencies
+        state.currencies = loadCurrenciesUseCase.getLocal()
         return Effect.none
     }
 

--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -57,7 +57,7 @@ private extension QuickView {
     }
 
     var calculationsSection: some View {
-        makeListSection(title: StringResource.calculations.localized) {
+        ListSection(title: StringResource.calculations.localized) {
             ForEach(store.quickCalculations, id: \.id) { calculation in
                 CurrencyCalculationRowView(
                     input: calculation.input,
@@ -71,7 +71,7 @@ private extension QuickView {
     }
 
     var allCurrenciesSection: some View {
-        makeListSection(title: StringResource.allCurrencies.localized) {
+        ListSection(title: StringResource.allCurrencies.localized) {
             ForEach(store.displayingCurrencies, id: \.id) { currency in
                 CurrencyRowView(
                     code: currency.id,
@@ -95,20 +95,6 @@ private extension QuickView {
                     .padding(16)
             }
         )
-    }
-}
-
-// MARK: - Helpers
-
-private extension QuickView {
-
-    func makeListSection<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
-        Section(header: Text(title)
-            .foregroundColor(Color.textTertiary)
-            .font(Font.customInterMedium(size: 14))
-        ) {
-            content()
-        }
     }
 }
 

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
@@ -27,8 +27,8 @@ struct SearchACurrencyFeature {
     // MARK: - Properties
 
     @Dependency(\.dismiss) var back
-    @Dependency(\.currencyRepository) var currencyRepository
-    @Dependency(\.getFrequentCurrenciesUseCase) var getFrequentCurrenciesUseCase
+    @Dependency(\.loadCurrenciesUseCase) var loadCurrenciesUseCase
+    @Dependency(\.loadFrequentCurrenciesUseCase) var loadFrequentCurrenciesUseCase
 
     // MARK: - Reducer
 
@@ -55,11 +55,8 @@ private extension SearchACurrencyFeature {
     }
 
     func loadCurrencies(_ state: inout State) -> Effect<Action> {
-        var currencies: [CurrencyDisplayModel] = []
-        do {
-            currencies = try currencyRepository.getLocal()
-                .map { CurrencyDisplayModel(from: $0) }
-        } catch {}
+        let currencies = loadCurrenciesUseCase.getLocal()
+            .map { CurrencyDisplayModel(from: $0) }
         state.currencies = currencies
         state.allCurrencies = currencies
         return Effect.none

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
@@ -8,6 +8,7 @@ struct SearchACurrencyFeature {
         var searchText = ""
         var currencies: [CurrencyDisplayModel] = []
         var allCurrencies: [CurrencyDisplayModel] = []
+        var frequentCurrencies: [CurrencyDisplayModel] = []
     }
 
     enum Action {
@@ -36,6 +37,7 @@ struct SearchACurrencyFeature {
         switch action {
         case .backButtonTapped: backButtonTapped()
         case .loadCurrencies: loadCurrencies(&state)
+        case .loadFrequentCurrencies: loadFrequentCurrencies(&state)
         case .searchTextUpdated(let searchText): searchTextUpdated(&state, searchText)
         case .currencyCodeSelected(let code): currencyCodeSelected(&state, code)
         default: Effect.none
@@ -59,6 +61,12 @@ private extension SearchACurrencyFeature {
             .map { CurrencyDisplayModel(from: $0) }
         state.currencies = currencies
         state.allCurrencies = currencies
+        return Effect.none
+    }
+
+    func loadFrequentCurrencies(_ state: inout State) -> Effect<Action> {
+        state.frequentCurrencies = loadFrequentCurrenciesUseCase.execute()
+            .map { CurrencyDisplayModel(from: $0) }
         return Effect.none
     }
 

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
@@ -14,6 +14,7 @@ struct SearchACurrencyFeature {
         case backButtonTapped
         case delegate(Delegate)
         case loadCurrencies
+        case loadFrequentCurrencies
         case searchTextUpdated(String)
         case currencyCodeSelected(String)
 
@@ -27,6 +28,7 @@ struct SearchACurrencyFeature {
 
     @Dependency(\.dismiss) var back
     @Dependency(\.currencyRepository) var currencyRepository
+    @Dependency(\.getFrequentCurrenciesUseCase) var getFrequentCurrenciesUseCase
 
     // MARK: - Reducer
 

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
@@ -49,10 +49,7 @@ private extension SearchACurrencyView {
     }
 
     var allCurrenciesSection: some View {
-        Section(header: Text(StringResource.allCurrencies.localized)
-            .foregroundColor(Color.textTertiary)
-            .font(Font.customInterMedium(size: 14))
-        ) {
+        ListSection(title: StringResource.allCurrencies.localized) {
             ForEach(store.currencies, id: \.id) { currency in
                 CurrencyRowView(
                     code: currency.id,

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
@@ -17,6 +17,7 @@ struct SearchACurrencyView: View {
             searchBar
             List {
                 allCurrenciesSection
+                frequentCurrenciesSection
             }
             .listStyle(.plain)
         }
@@ -29,6 +30,7 @@ struct SearchACurrencyView: View {
         )
         .onAppear {
             store.send(.loadCurrencies)
+            store.send(.loadFrequentCurrencies)
         }
     }
 }
@@ -60,6 +62,22 @@ private extension SearchACurrencyView {
             }
         }
     }
+
+    @ViewBuilder
+    var frequentCurrenciesSection: some View {
+        if !store.frequentCurrencies.isEmpty {
+            ListSection(title: StringResource.frequentCurrencies.localized) {
+                ForEach(store.frequentCurrencies, id: \.id) { currency in
+                    CurrencyRowView(
+                        code: currency.id,
+                        name: currency.name,
+                        action: { store.send(.currencyCodeSelected(currency.id)) }
+                    )
+                    .modifier(PlainListRowModifier())
+                }
+            }
+        }
+    }
 }
 
 // MARK: - Constants
@@ -74,6 +92,7 @@ private extension SearchACurrencyView {
         case title = "search_a_currency"
         case search = "Search"
         case allCurrencies = "all_currencies"
+        case frequentCurrencies = "frequent_currencies"
 
         var localized: String {
             String(localized: rawValue)

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyView.swift
@@ -16,8 +16,8 @@ struct SearchACurrencyView: View {
         VStack(spacing: 0) {
             searchBar
             List {
-                allCurrenciesSection
                 frequentCurrenciesSection
+                allCurrenciesSection
             }
             .listStyle(.plain)
         }
@@ -50,19 +50,6 @@ private extension SearchACurrencyView {
         .padding(.horizontal, Constants.spacing)
     }
 
-    var allCurrenciesSection: some View {
-        ListSection(title: StringResource.allCurrencies.localized) {
-            ForEach(store.currencies, id: \.id) { currency in
-                CurrencyRowView(
-                    code: currency.id,
-                    name: currency.name,
-                    action: { store.send(.currencyCodeSelected(currency.id)) }
-                )
-                .modifier(PlainListRowModifier())
-            }
-        }
-    }
-
     @ViewBuilder
     var frequentCurrenciesSection: some View {
         if !store.frequentCurrencies.isEmpty {
@@ -75,6 +62,19 @@ private extension SearchACurrencyView {
                     )
                     .modifier(PlainListRowModifier())
                 }
+            }
+        }
+    }
+
+    var allCurrenciesSection: some View {
+        ListSection(title: StringResource.allCurrencies.localized) {
+            ForEach(store.currencies, id: \.id) { currency in
+                CurrencyRowView(
+                    code: currency.id,
+                    name: currency.name,
+                    action: { store.send(.currencyCodeSelected(currency.id)) }
+                )
+                .modifier(PlainListRowModifier())
             }
         }
     }


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
[Quick] Add Frequent currencies to Search a currency screen

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Add CurrencyStatisticModel
- Save CurrencyStatistic when user added a QuickCalculation
- Add Frequent currencies to Search a currency screen

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| Light Mode | Dark Mode |
|------------|------------|
| ![Simulator Screenshot - iPhone 16 - 2025-04-11 at 19 43 57](https://github.com/user-attachments/assets/e6b420a2-c412-4a1c-8bcf-ca323c2200f8) | ![Simulator Screenshot - iPhone 16 - 2025-04-11 at 19 45 04](https://github.com/user-attachments/assets/7c414550-0df9-4fd9-985c-826662ccdb49) |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[[Quick] Add Frequent currencies to Search a currency screen](https://app.asana.com/1/1207783906637200/project/1209031794063268/task/1209785861833236?focus=true)