### PR TITLE
[Quick] Add Frequent currencies section to Quick screen

### DIFF
--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -21,6 +21,7 @@ struct QuickView: View {
             }
             .onAppear {
                 store.send(.loadCurrencies)
+                store.send(.loadFrequentCurrencies)
             }
         }
     }
@@ -49,6 +50,7 @@ private extension QuickView {
         ZStack(alignment: .bottomTrailing) {
             List {
                 calculationsSection
+                frequentCurrenciesSection
                 allCurrenciesSection
             }
             .listStyle(.plain)
@@ -66,6 +68,22 @@ private extension QuickView {
                     action: {}
                 )
                 .modifier(PlainListRowModifier())
+            }
+        }
+    }
+
+    @ViewBuilder
+    var frequentCurrenciesSection: some View {
+        if !store.frequentCurrencies.isEmpty {
+            ListSection(title: StringResource.frequentCurrencies.localized) {
+                ForEach(store.frequentCurrencies, id: \.id) { currency in
+                    CurrencyRowView(
+                        code: currency.id,
+                        name: currency.name,
+                        action: {}
+                    )
+                    .modifier(PlainListRowModifier())
+                }
             }
         }
     }
@@ -107,6 +125,7 @@ private extension QuickView {
         case calculations
         case calculatedOnAgo = "calculated_on_ago"
         case allCurrencies = "all_currencies"
+        case frequentCurrencies = "frequent_currencies"
 
         var localized: String {
             String(localized: rawValue)


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
[Quick] Add Frequent currencies section to Quick screen

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Add Frequent currencies section to Quick screen

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| Light Mode | Dark Mode |
|------------|------------|
| ![Simulator Screenshot - iPhone 16 - 2025-04-11 at 20 10 34](https://github.com/user-attachments/assets/e1a4c93c-4958-4ddc-95a6-5b7c53d3985a) | ![Simulator Screenshot - iPhone 16 - 2025-04-11 at 20 10 28](https://github.com/user-attachments/assets/bd17bf10-99df-4d9a-8455-44555e38d078) |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[[Quick] Add Frequent currencies section to Quick screen](https://app.asana.com/1/1207783906637200/project/1209031794063268/task/1209638463619218?focus=true)