### PR TITLE
[Quick] Add Pinned pairs section to Quick screen

### DIFF
--- a/ARK Rate/Localizable.xcstrings
+++ b/ARK Rate/Localizable.xcstrings
@@ -1495,6 +1495,17 @@
         }
       }
     },
+    "pin" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin"
+          }
+        }
+      }
+    },
     "pinned_pairs" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1989,6 +2000,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ugandan Shilling"
+          }
+        }
+      }
+    },
+    "unpin" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unpin"
           }
         }
       }

--- a/ARK Rate/Localizable.xcstrings
+++ b/ARK Rate/Localizable.xcstrings
@@ -1132,6 +1132,17 @@
         }
       }
     },
+    "last_refreshed_ago" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last refreshed %@ ago"
+          }
+        }
+      }
+    },
     "LBP" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1480,6 +1491,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Philippine Peso"
+          }
+        }
+      }
+    },
+    "pinned_pairs" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinned Pairs"
           }
         }
       }

--- a/ARK Rate/Sources/App/AppDependencies.swift
+++ b/ARK Rate/Sources/App/AppDependencies.swift
@@ -22,6 +22,11 @@ extension DependencyValues {
         set { self[CurrencyCalculationUseCaseKey.self] = newValue }
     }
 
+    var togglePinnedCalculationUseCase: TogglePinnedCalculationUseCase {
+        get { self[TogglePinnedCalculationUseCaseKey.self] }
+        set { self[TogglePinnedCalculationUseCaseKey.self] = newValue }
+    }
+
     var currencyRepository: CurrencyRepository {
         get { self[CurrencyRepositoryKey.self] }
         set { self[CurrencyRepositoryKey.self] = newValue }
@@ -98,6 +103,15 @@ private enum CurrencyCalculationUseCaseKey: DependencyKey {
 
     static let liveValue: CurrencyCalculationUseCase = CurrencyCalculationUseCase(
         currencyRepository: DependencyValues._current.currencyRepository
+    )
+}
+
+// MARK: - TogglePinnedCalculationUseCase
+
+private enum TogglePinnedCalculationUseCaseKey: DependencyKey {
+
+    static let liveValue: TogglePinnedCalculationUseCase = TogglePinnedCalculationUseCase(
+        quickCalculationRepository: DependencyValues._current.quickCalculationRepository
     )
 }
 

--- a/ARK Rate/Sources/Core/Data/DataSources/CurrencyLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/CurrencyLocalDataSource.swift
@@ -1,15 +1,11 @@
 protocol CurrencyLocalDataSource {
 
-    func get(where code: String?) throws -> CurrencyDTO?
+    func get(where code: String) throws -> CurrencyDTO?
     func get(where codes: [String]?) throws -> [CurrencyDTO]
     func save(_ currencies: [CurrencyDTO]) throws
 }
 
 extension CurrencyLocalDataSource {
-
-    func get() throws -> CurrencyDTO? {
-        try get(where: nil)
-    }
 
     func get() throws -> [CurrencyDTO] {
         try get(where: nil)

--- a/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationLocalDataSource.swift
@@ -1,5 +1,6 @@
 protocol QuickCalculationLocalDataSource {
 
     func get() throws -> [QuickCalculationDTO]
+    func getWherePinned() throws -> [QuickCalculationDTO]
     func save(_ calculation: QuickCalculationDTO) throws
 }

--- a/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationLocalDataSource.swift
@@ -1,5 +1,8 @@
+import Foundation
+
 protocol QuickCalculationLocalDataSource {
 
+    func get(where id: UUID) throws -> QuickCalculationDTO?
     func get() throws -> [QuickCalculationDTO]
     func getWherePinned() throws -> [QuickCalculationDTO]
     func save(_ calculation: QuickCalculationDTO) throws

--- a/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/CurrencySwiftDataDataSource.swift
@@ -4,15 +4,8 @@ struct CurrencySwiftDataDataSource: CurrencyLocalDataSource {
 
     // MARK: - Conformance
 
-    func get(where code: String?) throws -> CurrencyDTO? {
-        let predicate: Predicate<CurrencyModel>? = {
-            if let code {
-                return #Predicate { $0.code == code }
-            } else {
-                return nil
-            }
-        }()
-        let fetchedModel: CurrencyModel? = try SwiftDataManager.shared.get(predicate: predicate)
+    func get(where code: String) throws -> CurrencyDTO? {
+        let fetchedModel: CurrencyModel? = try SwiftDataManager.shared.get(predicate: #Predicate { $0.code == code })
         return fetchedModel.map(\.toCurrencyDTO)
     }
 

--- a/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
@@ -1,4 +1,4 @@
-import SwiftData
+import Foundation
 
 struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
 
@@ -6,6 +6,11 @@ struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
 
     func get() throws -> [QuickCalculationDTO] {
         let models: [QuickCalculationModel] = try SwiftDataManager.shared.get()
+        return models.map(\.toQuickCalculationDTO)
+    }
+
+    func getWherePinned() throws -> [QuickCalculationDTO] {
+        let models: [QuickCalculationModel] = try SwiftDataManager.shared.get(predicate: #Predicate { $0.pinnedDate != nil })
         return models.map(\.toQuickCalculationDTO)
     }
 

--- a/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
@@ -4,6 +4,11 @@ struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
 
     // MARK: - Conformance
 
+    func get(where id: UUID) throws -> QuickCalculationDTO? {
+        let model: QuickCalculationModel? = try SwiftDataManager.shared.get(predicate: #Predicate { $0.id == id })
+        return model.map(\.toQuickCalculationDTO)
+    }
+
     func get() throws -> [QuickCalculationDTO] {
         let models: [QuickCalculationModel] = try SwiftDataManager.shared.get()
         return models.map(\.toQuickCalculationDTO)
@@ -15,7 +20,13 @@ struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
     }
 
     func save(_ calculation: QuickCalculationDTO) throws {
+        let id = calculation.id
         let model = calculation.toQuickCalculationModel
-        try SwiftDataManager.shared.insert(model)
+        if let fetchedModel: QuickCalculationModel = try SwiftDataManager.shared.get(predicate: #Predicate { $0.id == id }) {
+            fetchedModel.pinnedDate = model.pinnedDate
+            try SwiftDataManager.shared.save()
+        } else {
+            try SwiftDataManager.shared.insert(model)
+        }
     }
 }

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -20,7 +20,19 @@ extension QuickCalculation {
         ([inputCurrencyCode] + outputCurrencyCodes).map { CurrencyStatistic(code: $0) }
     }
 
-    func toQuickCalculation(with outputCurrencyAmounts: [Decimal]) -> QuickCalculation {
+    func toQuickCalculation(outputCurrencyAmounts: [Decimal]) -> QuickCalculation {
+        QuickCalculation(
+            id: id,
+            pinnedDate: pinnedDate,
+            calculatedDate: calculatedDate,
+            inputCurrencyCode: inputCurrencyCode,
+            inputCurrencyAmount: inputCurrencyAmount,
+            outputCurrencyCodes: outputCurrencyCodes,
+            outputCurrencyAmounts: outputCurrencyAmounts
+        )
+    }
+
+    func toQuickCalculation(pinnedDate: Date?) -> QuickCalculation {
         QuickCalculation(
             id: id,
             pinnedDate: pinnedDate,

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // MARK: -
 
 extension QuickCalculation {
@@ -16,6 +18,18 @@ extension QuickCalculation {
 
     var toCurrencyStatistics: [CurrencyStatistic] {
         ([inputCurrencyCode] + outputCurrencyCodes).map { CurrencyStatistic(code: $0) }
+    }
+
+    func toQuickCalculation(with outputCurrencyAmounts: [Decimal]) -> QuickCalculation {
+        QuickCalculation(
+            id: id,
+            pinnedDate: pinnedDate,
+            calculatedDate: calculatedDate,
+            inputCurrencyCode: inputCurrencyCode,
+            inputCurrencyAmount: inputCurrencyAmount,
+            outputCurrencyCodes: outputCurrencyCodes,
+            outputCurrencyAmounts: outputCurrencyAmounts
+        )
     }
 }
 

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -20,7 +20,10 @@ extension QuickCalculation {
         ([inputCurrencyCode] + outputCurrencyCodes).map { CurrencyStatistic(code: $0) }
     }
 
-    func toQuickCalculation(outputCurrencyAmounts: [Decimal]) -> QuickCalculation {
+    func toQuickCalculation(
+        calculatedDate: Date,
+        outputCurrencyAmounts: [Decimal]
+    ) -> QuickCalculation {
         QuickCalculation(
             id: id,
             pinnedDate: pinnedDate,

--- a/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/CurrencyRepositoryImpl.swift
@@ -33,7 +33,7 @@ final class CurrencyRepositoryImpl: CurrencyRepository {
         return currencies.map(\.toCurrency)
     }
 
-    func getLocal(where code: String?) throws -> Currency? {
+    func getLocal(where code: String) throws -> Currency? {
         try localDataSource.get(where: code).map(\.toCurrency)
     }
 

--- a/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 final class QuickCalculationRepositoryImpl: QuickCalculationRepository {
 
     // MARK: - Properties
@@ -11,6 +13,10 @@ final class QuickCalculationRepositoryImpl: QuickCalculationRepository {
     }
 
     // MARK: - Conformance
+
+    func get(where id: UUID) throws -> QuickCalculation? {
+        try localDataSource.get(where: id).map(\.toQuickCalculation)
+    }
 
     func get() throws -> [QuickCalculation] {
         try localDataSource.get().map(\.toQuickCalculation)

--- a/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
@@ -16,6 +16,10 @@ final class QuickCalculationRepositoryImpl: QuickCalculationRepository {
         try localDataSource.get().map(\.toQuickCalculation)
     }
 
+    func getWherePinned() throws -> [QuickCalculation] {
+        try localDataSource.getWherePinned().map(\.toQuickCalculation)
+    }
+
     func save(_ calculation: QuickCalculation) throws {
         try localDataSource.save(calculation.toQuickCalculationDTO)
     }

--- a/ARK Rate/Sources/Core/Domain/Mappers/DomainCurrencyMapper.swift
+++ b/ARK Rate/Sources/Core/Domain/Mappers/DomainCurrencyMapper.swift
@@ -1,0 +1,6 @@
+extension Currency {
+
+    var toCurrencyDisplayModel: CurrencyDisplayModel {
+        CurrencyDisplayModel(code: code)
+    }
+}

--- a/ARK Rate/Sources/Core/Domain/Mappers/DomainQuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Domain/Mappers/DomainQuickCalculationMapper.swift
@@ -3,6 +3,7 @@ extension QuickCalculation {
     var toQuickCalculationDisplayModel: QuickCalculationDisplayModel {
         QuickCalculationDisplayModel(
             id: id,
+            pinnedDate: pinnedDate,
             calculatedDate: calculatedDate,
             input: CurrencyDisplayModel(
                 code: inputCurrencyCode,

--- a/ARK Rate/Sources/Core/Domain/Mappers/DomainQuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Domain/Mappers/DomainQuickCalculationMapper.swift
@@ -1,0 +1,19 @@
+extension QuickCalculation {
+
+    var toQuickCalculationDisplayModel: QuickCalculationDisplayModel {
+        QuickCalculationDisplayModel(
+            id: id,
+            calculatedDate: calculatedDate,
+            input: CurrencyDisplayModel(
+                code: inputCurrencyCode,
+                amount: inputCurrencyAmount
+            ),
+            outputs: zip(outputCurrencyCodes, outputCurrencyAmounts).map { code, amount in
+                CurrencyDisplayModel(
+                    code: code,
+                    amount: amount
+                )
+            }
+        )
+    }
+}

--- a/ARK Rate/Sources/Core/Domain/Repositories/CurrencyRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/CurrencyRepository.swift
@@ -1,15 +1,11 @@
 protocol CurrencyRepository {
 
     func fetchRemote() async throws -> [Currency]
-    func getLocal(where code: String?) throws -> Currency?
+    func getLocal(where code: String) throws -> Currency?
     func getLocal(where codes: [String]?) throws -> [Currency]
 }
 
 extension CurrencyRepository {
-
-    func getLocal() throws -> Currency? {
-        try getLocal(where: nil)
-    }
 
     func getLocal() throws -> [Currency] {
         try getLocal(where: nil)

--- a/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationRepository.swift
@@ -1,5 +1,6 @@
 protocol QuickCalculationRepository {
 
     func get() throws -> [QuickCalculation]
+    func getWherePinned() throws -> [QuickCalculation]
     func save(_ calculation: QuickCalculation) throws
 }

--- a/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationRepository.swift
@@ -1,5 +1,8 @@
+import Foundation
+
 protocol QuickCalculationRepository {
 
+    func get(where id: UUID) throws -> QuickCalculation?
     func get() throws -> [QuickCalculation]
     func getWherePinned() throws -> [QuickCalculation]
     func save(_ calculation: QuickCalculation) throws

--- a/ARK Rate/Sources/Core/Domain/UseCases/CurrencyCalculationUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/CurrencyCalculationUseCase.swift
@@ -13,15 +13,11 @@ struct CurrencyCalculationUseCase {
         inputCurrencyAmount: Decimal,
         outputCurrencyCode: String
     ) -> Decimal {
-        do {
-            guard let inputCurrency = try currencyRepository.getLocal(where: inputCurrencyCode),
-                  let outputCurrency = try currencyRepository.getLocal(where: outputCurrencyCode) else {
-                return 0
-            }
-            let rate = inputCurrency.rate.divideArk(outputCurrency.rate)
-            return inputCurrencyAmount * rate
-        } catch {
+        guard let inputCurrency = try? currencyRepository.getLocal(where: inputCurrencyCode),
+              let outputCurrency = try? currencyRepository.getLocal(where: outputCurrencyCode) else {
             return 0
         }
+        let rate = inputCurrency.rate.divideArk(outputCurrency.rate)
+        return inputCurrencyAmount * rate
     }
 }

--- a/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
@@ -10,4 +10,24 @@ struct LoadQuickCalculationsUseCase {
     func getCalculatedCalculations() -> [QuickCalculation] {
         (try? quickCalculationRepository.get().sorted { $0.calculatedDate > $1.calculatedDate }) ?? []
     }
+
+    func getPinnedCalculations() -> [QuickCalculation] {
+        do {
+            return try quickCalculationRepository.getWherePinned()
+                .map { calculation in
+                    var outputCurrencyAmounts = calculation.outputCurrencyAmounts
+                    for (index, outputCurrencyCode) in calculation.outputCurrencyCodes.enumerated() {
+                        outputCurrencyAmounts[index] = currencyCalculationUseCase.execute(
+                            inputCurrencyCode: calculation.inputCurrencyCode,
+                            inputCurrencyAmount: calculation.inputCurrencyAmount,
+                            outputCurrencyCode: outputCurrencyCode
+                        )
+                    }
+                    return calculation.toQuickCalculation(with: outputCurrencyAmounts)
+                }
+                .sorted { $0.calculatedDate > $1.calculatedDate }
+        } catch {
+            return []
+        }
+    }
 }

--- a/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct LoadQuickCalculationsUseCase {
 
     // MARK: - Properties
@@ -23,7 +25,10 @@ struct LoadQuickCalculationsUseCase {
                             outputCurrencyCode: outputCurrencyCode
                         )
                     }
-                    return calculation.toQuickCalculation(outputCurrencyAmounts: outputCurrencyAmounts)
+                    return calculation.toQuickCalculation(
+                        calculatedDate: Date(),
+                        outputCurrencyAmounts: outputCurrencyAmounts
+                    )
                 }
                 .sorted { $0.calculatedDate > $1.calculatedDate }
         } catch {

--- a/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
@@ -23,7 +23,7 @@ struct LoadQuickCalculationsUseCase {
                             outputCurrencyCode: outputCurrencyCode
                         )
                     }
-                    return calculation.toQuickCalculation(with: outputCurrencyAmounts)
+                    return calculation.toQuickCalculation(outputCurrencyAmounts: outputCurrencyAmounts)
                 }
                 .sorted { $0.calculatedDate > $1.calculatedDate }
         } catch {

--- a/ARK Rate/Sources/Core/Domain/UseCases/TogglePinnedCalculationUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/TogglePinnedCalculationUseCase.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct TogglePinnedCalculationUseCase {
+
+    // MARK: - Properties
+
+    let quickCalculationRepository: QuickCalculationRepository
+
+    // MARK: - Methods
+
+    func execute(_ id: UUID) -> QuickCalculation? {
+        guard let calculation = try? quickCalculationRepository.get(where: id) else { return nil }
+        let pinnedDate: Date? = calculation.pinnedDate == nil ? Date() : nil
+        let updated = calculation.toQuickCalculation(pinnedDate: pinnedDate)
+        try? quickCalculationRepository.save(updated)
+        return updated
+    }
+}

--- a/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationFeature.swift
@@ -134,17 +134,15 @@ private extension AddQuickCalculationFeature {
 
     func saveButtonTapped(_ state: inout State) -> Effect<Action> {
         guard state.canSave else { return Effect.none }
-        do {
-            let quickCalculation = QuickCalculation(
-                inputCurrencyCode: state.inputCurrency.code,
-                inputCurrencyAmount: state.inputCurrency.amount,
-                outputCurrencyCodes: state.outputCurrencies.map(\.code),
-                outputCurrencyAmounts: state.outputCurrencies.map(\.amount)
-            )
-            let currencyStatistics = quickCalculation.toCurrencyStatistics
-            try quickCalculationRepository.save(quickCalculation)
-            try currencyStatisticRepository.save(currencyStatistics)
-        } catch {}
+        let quickCalculation = QuickCalculation(
+            inputCurrencyCode: state.inputCurrency.code,
+            inputCurrencyAmount: state.inputCurrency.amount,
+            outputCurrencyCodes: state.outputCurrencies.map(\.code),
+            outputCurrencyAmounts: state.outputCurrencies.map(\.amount)
+        )
+        let currencyStatistics = quickCalculation.toCurrencyStatistics
+        try? quickCalculationRepository.save(quickCalculation)
+        try? currencyStatisticRepository.save(currencyStatistics)
         return Effect.run { send in
             await send(.delegate(.back))
             await back()

--- a/ARK Rate/Sources/Features/Quick/QuickCalculationDisplayModel.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickCalculationDisplayModel.swift
@@ -1,25 +1,46 @@
 import Foundation
 
-struct QuickCalculationDisplayModel: Equatable {
+struct QuickCalculationDisplayModel: Identifiable, Equatable {
 
     // MARK: - Properties
 
     let id: UUID
+    let pinned: Bool
     let elapsedTime: String
     let input: CurrencyDisplayModel
     let outputs: [CurrencyDisplayModel]
+
+    var togglePinnedTitle: String {
+        !pinned ? StringResource.pin.localized : StringResource.unpin.localized
+    }
 
     // MARK: - Initialization
 
     init(
         id: UUID,
+        pinnedDate: Date?,
         calculatedDate: Date,
         input: CurrencyDisplayModel,
         outputs: [CurrencyDisplayModel]
     ) {
         self.id = id
+        self.pinned = pinnedDate != nil
         self.elapsedTime = calculatedDate.formattedElapsedTime
         self.input = input
         self.outputs = outputs
+    }
+}
+
+// MARK: - Constants
+
+private extension QuickCalculationDisplayModel {
+
+    enum StringResource: String.LocalizationValue {
+        case pin
+        case unpin
+
+        var localized: String {
+            String(localized: rawValue)
+        }
     }
 }

--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -84,6 +84,11 @@ private extension QuickView {
                     elapsedTime: StringResource.calculatedOnAgo.localizedFormat(calculation.elapsedTime),
                     action: {}
                 )
+                .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                    makeTogglePinnedButton(for: calculation, action: {
+                        store.send(.togglePinnedButtonTapped(id: calculation.id))
+                    })
+                }
                 .modifier(PlainListRowModifier())
             }
         }
@@ -133,9 +138,33 @@ private extension QuickView {
     }
 }
 
+// MARK: - Helpers
+
+private extension QuickView {
+
+    func makeTogglePinnedButton(
+        for calculation: QuickCalculationDisplayModel,
+        action: @escaping ButtonAction
+    ) -> some View {
+        Button(
+            action: action,
+            label: {
+                Text(calculation.togglePinnedTitle)
+                    .foregroundColor(Color.white)
+                    .padding(Constants.spacing)
+            }
+        )
+        .tint(Color.teal600)
+    }
+}
+
 // MARK: - Constants
 
 private extension QuickView {
+
+    enum Constants {
+        static let spacing: CGFloat = 16
+    }
 
     enum StringResource: String.LocalizationValue {
         case title = "quick_title"

--- a/ARK Rate/Sources/Features/Quick/QuickView.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickView.swift
@@ -20,7 +20,7 @@ struct QuickView: View {
                 AddQuickCalculationView(store: store)
             }
             .onAppear {
-                store.send(.loadQuickCalculations)
+                store.send(.loadCalculatedCalculations)
             }
         }
     }
@@ -48,12 +48,30 @@ private extension QuickView {
     var list: some View {
         ZStack(alignment: .bottomTrailing) {
             List {
+                pinnedPairsSection
                 calculatedCalculationsSection
                 frequentCurrenciesSection
                 allCurrenciesSection
             }
             .listStyle(.plain)
             addButton
+        }
+    }
+
+    @ViewBuilder
+    var pinnedPairsSection: some View {
+        if !store.pinnedCalculations.isEmpty {
+            ListSection(title: StringResource.pinnedPairs.localized) {
+                ForEach(store.pinnedCalculations, id: \.id) { calculation in
+                    CurrencyCalculationRowView(
+                        input: calculation.input,
+                        outputs: calculation.outputs,
+                        elapsedTime: StringResource.lastRefreshedAgo.localizedFormat(calculation.elapsedTime),
+                        action: {}
+                    )
+                    .modifier(PlainListRowModifier())
+                }
+            }
         }
     }
 
@@ -121,7 +139,9 @@ private extension QuickView {
 
     enum StringResource: String.LocalizationValue {
         case title = "quick_title"
+        case pinnedPairs = "pinned_pairs"
         case calculations
+        case lastRefreshedAgo = "last_refreshed_ago"
         case calculatedOnAgo = "calculated_on_ago"
         case allCurrencies = "all_currencies"
         case frequentCurrencies = "frequent_currencies"

--- a/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/SearchACurrency/SearchACurrencyFeature.swift
@@ -58,7 +58,7 @@ private extension SearchACurrencyFeature {
 
     func loadCurrencies(_ state: inout State) -> Effect<Action> {
         let currencies = loadCurrenciesUseCase.getLocal()
-            .map { CurrencyDisplayModel(code: $0.code) }
+            .map(\.toCurrencyDisplayModel)
         state.currencies = currencies
         state.allCurrencies = currencies
         return Effect.none
@@ -66,7 +66,7 @@ private extension SearchACurrencyFeature {
 
     func loadFrequentCurrencies(_ state: inout State) -> Effect<Action> {
         state.frequentCurrencies = loadFrequentCurrenciesUseCase.execute()
-            .map { CurrencyDisplayModel(code: $0.code) }
+            .map(\.toCurrencyDisplayModel)
         return Effect.none
     }
 


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
[Quick] Add Pinned pairs section to Quick screen

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Add Pinned pairs section to Quick screen
- Add Pinned toggle buttons to each calculation

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| Light Mode | Dark Mode |
|------------|------------|
| ![IMG_2369](https://github.com/user-attachments/assets/9057734f-9b24-4704-b2c4-d751616b3a2e) | ![IMG_2370](https://github.com/user-attachments/assets/4d08ceb5-d777-415f-b063-9bbf8c3c4c23) |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[[Quick] Add Pinned pairs section to Quick screen](https://app.asana.com/1/1207783906637200/project/1209031794063268/task/1209638463619222?focus=true)