### PR TITLE
Assign Group to Quick Calculation

### DIFF
--- a/ARK Rate/Localizable.xcstrings
+++ b/ARK Rate/Localizable.xcstrings
@@ -160,6 +160,17 @@
         }
       }
     },
+    "default" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default"
+          }
+        }
+      }
+    },
     "delete" : {
       "localizations" : {
         "en" : {

--- a/ARK Rate/Sources/App/ARKRateApp.swift
+++ b/ARK Rate/Sources/App/ARKRateApp.swift
@@ -30,7 +30,7 @@ struct ARKRateApp: App {
 
     init() {
         SwiftDataManager.shared.modelContext = sharedModelContainer.mainContext
-        store.send(.currenciesAction(.fetchCurrencies))
+        store.send(.didFinishLaunching)
     }
 
     // MARK: - Body

--- a/ARK Rate/Sources/App/AppDependencies.swift
+++ b/ARK Rate/Sources/App/AppDependencies.swift
@@ -17,6 +17,11 @@ extension DependencyValues {
         set { self[LoadQuickCalculationsUseCaseKey.self] = newValue }
     }
 
+    var loadQuickCalculationGroupsUseCaseKey: LoadQuickCalculationGroupsUseCase {
+        get { self[LoadQuickCalculationGroupsUseCaseKey.self] }
+        set { self[LoadQuickCalculationGroupsUseCaseKey.self] = newValue }
+    }
+
     var currencyCalculationUseCase: CurrencyCalculationUseCase {
         get { self[CurrencyCalculationUseCaseKey.self] }
         set { self[CurrencyCalculationUseCaseKey.self] = newValue }
@@ -40,6 +45,11 @@ extension DependencyValues {
     var quickCalculationRepository: QuickCalculationRepository {
         get { self[QuickCalculationRepositoryKey.self] }
         set { self[QuickCalculationRepositoryKey.self] = newValue }
+    }
+
+    var quickCalculationGroupRepository: QuickCalculationGroupRepository {
+        get { self[QuickCalculationGroupRepositoryKey.self] }
+        set { self[QuickCalculationGroupRepositoryKey.self] = newValue }
     }
 
     var metadataRepository: MetadataRepository {
@@ -71,6 +81,11 @@ extension DependencyValues {
         get { self[QuickCalculationLocalDataSourceKey.self] }
         set { self[QuickCalculationLocalDataSourceKey.self] = newValue }
     }
+
+    var quickCalculationGroupLocalDataSource: QuickCalculationGroupLocalDataSource {
+        get { self[QuickCalculationGroupLocalDataSourceKey.self] }
+        set { self[QuickCalculationGroupLocalDataSourceKey.self] = newValue }
+    }
 }
 
 // MARK: - LoadCurrenciesUseCase
@@ -101,6 +116,15 @@ private enum LoadQuickCalculationsUseCaseKey: DependencyKey {
         quickCalculationRepository: DependencyValues._current.quickCalculationRepository,
         currencyCalculationUseCase: DependencyValues._current.currencyCalculationUseCase,
         metadataRepository: DependencyValues._current.metadataRepository
+    )
+}
+
+// MARK: - LoadQuickCalculationGroupsUseCase
+
+private enum LoadQuickCalculationGroupsUseCaseKey: DependencyKey {
+
+    static let liveValue: LoadQuickCalculationGroupsUseCase = LoadQuickCalculationGroupsUseCase(
+        quickCalculationGroupRepository: DependencyValues._current.quickCalculationGroupRepository
     )
 }
 
@@ -144,6 +168,15 @@ private enum QuickCalculationRepositoryKey: DependencyKey {
 
     static let liveValue: QuickCalculationRepository = QuickCalculationRepositoryImpl(
         localDataSource: DependencyValues._current.quickCalculationLocalDataSource
+    )
+}
+
+// MARK: - QuickCalculationGroupRepositoryKey
+
+private enum QuickCalculationGroupRepositoryKey: DependencyKey {
+
+    static let liveValue: QuickCalculationGroupRepository = QuickCalculationGroupRepositoryImpl(
+        localDataSource: DependencyValues._current.quickCalculationGroupLocalDataSource
     )
 }
 
@@ -196,4 +229,11 @@ private enum CurrencyStatisticLocalDataSourceKey: DependencyKey {
 private enum QuickCalculationLocalDataSourceKey: DependencyKey {
 
     static let liveValue: QuickCalculationLocalDataSource = QuickCalculationSwiftDataDataSource()
+}
+
+// MARK: - QuickCalculationGroupLocalDataSourceKey
+
+private enum QuickCalculationGroupLocalDataSourceKey: DependencyKey {
+
+    static let liveValue: QuickCalculationGroupLocalDataSource = QuickCalculationGroupSwiftDataDataSource()
 }

--- a/ARK Rate/Sources/Core/Data/DTO/QuickCalculationDTO.swift
+++ b/ARK Rate/Sources/Core/Data/DTO/QuickCalculationDTO.swift
@@ -11,4 +11,5 @@ struct QuickCalculationDTO {
     let inputCurrencyAmount: Decimal
     let outputCurrencyCodes: [String]
     let outputCurrencyAmounts: [Decimal]
+    let group: QuickCalculationGroupDTO?
 }

--- a/ARK Rate/Sources/Core/Data/DTO/QuickCalculationGroupDTO.swift
+++ b/ARK Rate/Sources/Core/Data/DTO/QuickCalculationGroupDTO.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct QuickCalculationGroupDTO {
+
+    // MARK: - Properties
+
+    let id: UUID
+    let name: String
+    let addedDate: Date
+    let displayOrder: Int?
+}

--- a/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationGroupLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationGroupLocalDataSource.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol QuickCalculationGroupLocalDataSource {
+
+    func get() throws -> [QuickCalculationGroupDTO]
+    func get(where id: UUID) throws -> QuickCalculationGroupDTO?
+    func save(_ group: QuickCalculationGroupDTO) throws
+}

--- a/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationGroupModel.swift
+++ b/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationGroupModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftData
+
+@Model
+final class QuickCalculationGroupModel {
+
+    // MARK: - Properties
+
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var addedDate: Date
+    var displayOrder: Int?
+
+    @Relationship(deleteRule: .cascade) var calculations: [QuickCalculationModel]
+
+    // MARK: - Initialization
+
+    init(
+        id: UUID,
+        name: String,
+        addedDate: Date,
+        displayOrder: Int?
+    ) {
+        self.id = id
+        self.name = name
+        self.addedDate = addedDate
+        self.displayOrder = displayOrder
+        self.calculations = []
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationModel.swift
+++ b/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationModel.swift
@@ -14,6 +14,8 @@ final class QuickCalculationModel {
     var outputCurrencyCodes: [String]
     var outputCurrencyAmounts: [Decimal]
 
+    @Relationship var group: QuickCalculationGroupModel?
+
     // MARK: - Initialization
 
     init(
@@ -23,7 +25,8 @@ final class QuickCalculationModel {
         inputCurrencyCode: String,
         inputCurrencyAmount: Decimal,
         outputCurrencyCodes: [String],
-        outputCurrencyAmounts: [Decimal]
+        outputCurrencyAmounts: [Decimal],
+        group: QuickCalculationGroupModel?
     ) {
         self.id = id
         self.pinnedDate = pinnedDate
@@ -32,5 +35,6 @@ final class QuickCalculationModel {
         self.inputCurrencyAmount = inputCurrencyAmount
         self.outputCurrencyCodes = outputCurrencyCodes
         self.outputCurrencyAmounts = outputCurrencyAmounts
+        self.group = group
     }
 }

--- a/ARK Rate/Sources/Core/Data/Local/QuickCalculationGroupSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/QuickCalculationGroupSwiftDataDataSource.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct QuickCalculationGroupSwiftDataDataSource: QuickCalculationGroupLocalDataSource {
+
+    // MARK: - Conformance
+
+    func get() throws -> [QuickCalculationGroupDTO] {
+        let models: [QuickCalculationGroupModel] = try SwiftDataManager.shared.get()
+        return models.map(\.toQuickCalculationGroupDTO)
+    }
+
+    func get(where id: UUID) throws -> QuickCalculationGroupDTO? {
+        let model: QuickCalculationGroupModel? = try SwiftDataManager.shared.get(predicate: #Predicate { $0.id == id })
+        return model.map(\.toQuickCalculationGroupDTO)
+    }
+
+    func save(_ group: QuickCalculationGroupDTO) throws {
+        let name = group.name
+        let model = group.toQuickCalculationGroupModel
+        if let fetchedModel: QuickCalculationGroupModel = try SwiftDataManager.shared.get(predicate: #Predicate { $0.name == name }) {
+            fetchedModel.displayOrder = model.displayOrder
+            try SwiftDataManager.shared.save()
+        } else {
+            try SwiftDataManager.shared.insert(model)
+        }
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
@@ -29,6 +29,7 @@ struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
             fetchedModel.inputCurrencyAmount = model.inputCurrencyAmount
             fetchedModel.outputCurrencyCodes = model.outputCurrencyCodes
             fetchedModel.outputCurrencyAmounts = model.outputCurrencyAmounts
+            fetchedModel.group = model.group
             try SwiftDataManager.shared.save()
         } else {
             try SwiftDataManager.shared.insert(model)

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationGroupMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationGroupMapper.swift
@@ -1,0 +1,50 @@
+// MARK: -
+
+extension QuickCalculationGroup {
+
+    var toQuickCalculationGroupDTO: QuickCalculationGroupDTO {
+        QuickCalculationGroupDTO(
+            id: id,
+            name: name,
+            addedDate: addedDate,
+            displayOrder: displayOrder
+        )
+    }
+}
+
+// MARK: -
+
+extension QuickCalculationGroupDTO {
+
+    var toQuickCalculationGroup: QuickCalculationGroup {
+        QuickCalculationGroup(
+            id: id,
+            name: name,
+            addedDate: addedDate,
+            displayOrder: displayOrder
+        )
+    }
+
+    var toQuickCalculationGroupModel: QuickCalculationGroupModel {
+        QuickCalculationGroupModel(
+            id: id,
+            name: name,
+            addedDate: addedDate,
+            displayOrder: displayOrder
+        )
+    }
+}
+
+// MARK: -
+
+extension QuickCalculationGroupModel {
+
+    var toQuickCalculationGroupDTO: QuickCalculationGroupDTO {
+        QuickCalculationGroupDTO(
+            id: id,
+            name: name,
+            addedDate: addedDate,
+            displayOrder: displayOrder
+        )
+    }
+}

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -12,7 +12,8 @@ extension QuickCalculation {
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
-            outputCurrencyAmounts: outputCurrencyAmounts
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group?.toQuickCalculationGroupDTO
         )
     }
 
@@ -31,7 +32,8 @@ extension QuickCalculation {
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
-            outputCurrencyAmounts: outputCurrencyAmounts
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group
         )
     }
 
@@ -43,7 +45,8 @@ extension QuickCalculation {
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
-            outputCurrencyAmounts: outputCurrencyAmounts
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group
         )
     }
 }
@@ -60,7 +63,8 @@ extension QuickCalculationDTO {
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
-            outputCurrencyAmounts: outputCurrencyAmounts
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group?.toQuickCalculationGroup
         )
     }
 
@@ -72,7 +76,8 @@ extension QuickCalculationDTO {
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
-            outputCurrencyAmounts: outputCurrencyAmounts
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group?.toQuickCalculationGroupModel
         )
     }
 }
@@ -89,7 +94,8 @@ extension QuickCalculationModel {
             inputCurrencyCode: inputCurrencyCode,
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
-            outputCurrencyAmounts: outputCurrencyAmounts
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group?.toQuickCalculationGroupDTO
         )
     }
 }

--- a/ARK Rate/Sources/Core/Data/Repositories/MetadataRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/MetadataRepositoryImpl.swift
@@ -8,6 +8,14 @@ struct MetadataRepositoryImpl: MetadataRepository {
 
     // MARK: - Conformance
 
+    func recordHasLaunchedBefore() {
+        userDefaults.set(true, forKey: Keys.hasLaunchedBefore.rawValue)
+    }
+
+    func hasLaunchedBefore() -> Bool {
+        userDefaults.object(forKey: Keys.hasLaunchedBefore.rawValue) as? Bool ?? false
+    }
+
     func recordCurrenciesFetchDate() {
         userDefaults.set(Date(), forKey: Keys.currenciesFetchDate.rawValue)
     }
@@ -22,6 +30,7 @@ struct MetadataRepositoryImpl: MetadataRepository {
 private extension MetadataRepositoryImpl {
 
     enum Keys: String {
+        case hasLaunchedBefore
         case currenciesFetchDate
     }
 }

--- a/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationGroupRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationGroupRepositoryImpl.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct QuickCalculationGroupRepositoryImpl: QuickCalculationGroupRepository {
+
+    // MARK: - Properties
+
+    let localDataSource: QuickCalculationGroupLocalDataSource
+
+    // MARK: - Conformance
+
+    func get() throws -> [QuickCalculationGroup] {
+        try localDataSource.get().map(\.toQuickCalculationGroup)
+    }
+
+    func get(where id: UUID) throws -> QuickCalculationGroup? {
+        try localDataSource.get(where: id).map(\.toQuickCalculationGroup)
+    }
+
+    func save(_ group: QuickCalculationGroup) throws {
+        try localDataSource.save(group.toQuickCalculationGroupDTO)
+    }
+}

--- a/ARK Rate/Sources/Core/Domain/Entities/QuickCalculation.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/QuickCalculation.swift
@@ -11,6 +11,7 @@ struct QuickCalculation: Equatable {
     let inputCurrencyAmount: Decimal
     let outputCurrencyCodes: [String]
     let outputCurrencyAmounts: [Decimal]
+    let group: QuickCalculationGroup?
 
     // MARK: - Initialization
 
@@ -21,7 +22,8 @@ struct QuickCalculation: Equatable {
         inputCurrencyCode: String,
         inputCurrencyAmount: Decimal,
         outputCurrencyCodes: [String],
-        outputCurrencyAmounts: [Decimal]
+        outputCurrencyAmounts: [Decimal],
+        group: QuickCalculationGroup?
     ) {
         self.id = id
         self.pinnedDate = pinnedDate
@@ -30,5 +32,6 @@ struct QuickCalculation: Equatable {
         self.inputCurrencyAmount = inputCurrencyAmount
         self.outputCurrencyCodes = outputCurrencyCodes
         self.outputCurrencyAmounts = outputCurrencyAmounts
+        self.group = group
     }
 }

--- a/ARK Rate/Sources/Core/Domain/Entities/QuickCalculationGroup.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/QuickCalculationGroup.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct QuickCalculationGroup: Equatable {
+
+    // MARK: - Properties
+
+    let id: UUID
+    let name: String
+    let addedDate: Date
+    let displayOrder: Int?
+
+    // MARK: - Initialization
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        addedDate: Date = Date(),
+        displayOrder: Int? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.addedDate = addedDate
+        self.displayOrder = displayOrder
+    }
+}

--- a/ARK Rate/Sources/Core/Domain/Mappers/DomainQuickCalculationGroupMapper.swift
+++ b/ARK Rate/Sources/Core/Domain/Mappers/DomainQuickCalculationGroupMapper.swift
@@ -1,0 +1,10 @@
+extension QuickCalculationGroup {
+
+    var toGroupDisplayModel: GroupDisplayModel {
+        GroupDisplayModel(
+            id: id,
+            name: name,
+            displayOrder: displayOrder
+        )
+    }
+}

--- a/ARK Rate/Sources/Core/Domain/Repositories/MetadataRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/MetadataRepository.swift
@@ -2,6 +2,8 @@ import Foundation
 
 protocol MetadataRepository {
 
+    func recordHasLaunchedBefore()
+    func hasLaunchedBefore() -> Bool
     func recordCurrenciesFetchDate()
     func lastCurrenciesFetchDate() -> Date?
 }

--- a/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationGroupRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationGroupRepository.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol QuickCalculationGroupRepository {
+
+    func get() throws -> [QuickCalculationGroup]
+    func get(where id: UUID) throws -> QuickCalculationGroup?
+    func save(_ group: QuickCalculationGroup) throws
+}

--- a/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationGroupsUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationGroupsUseCase.swift
@@ -1,0 +1,23 @@
+struct LoadQuickCalculationGroupsUseCase {
+
+    // MARK: - Properties
+
+    let quickCalculationGroupRepository: QuickCalculationGroupRepository
+
+    // MARK: - Methods
+
+    func execute() -> [QuickCalculationGroup] {
+        (try? quickCalculationGroupRepository.get().sorted {
+            switch ($0.displayOrder, $1.displayOrder) {
+            case (nil, nil):
+                return $0.addedDate > $1.addedDate
+            case (nil, _):
+                return false
+            case (_, nil):
+                return true
+            default:
+                return $0.displayOrder! < $1.displayOrder!
+            }
+        }) ?? []
+    }
+}

--- a/ARK Rate/Sources/Core/Presentation/Components/GroupMenuView.swift
+++ b/ARK Rate/Sources/Core/Presentation/Components/GroupMenuView.swift
@@ -4,8 +4,10 @@ struct GroupMenuView: View {
 
     // MARK: - Properties
 
-    @Binding var groups: [String]
+    @Binding var groupName: String
+    let groups: [GroupDisplayModel]
     let addGroupAction: ButtonAction
+    let onSelectedGroupAction: SelectedAction<GroupDisplayModel>
 
     // MARK: - Body
 
@@ -17,8 +19,8 @@ struct GroupMenuView: View {
             HStack(spacing: Constants.itemSpacing) {
                 Image.folder
                     .foregroundColor(Color.foregroundQuarterary)
-                Text(StringResource.newGroup.localized)
-                    .foregroundColor(Color.textPlaceholder)
+                Text(groupName)
+                    .foregroundColor(Color.textPrimary)
                     .font(Font.customInterRegular(size: 16))
                 Spacer()
                 Image.chevronDown
@@ -36,26 +38,33 @@ struct GroupMenuView: View {
 private extension GroupMenuView {
 
     var newGroupItem: some View {
-        Button(action: addGroupAction) {
-            item(name: StringResource.newGroup.localized)
-        }
+        Button(
+            action: addGroupAction,
+            label: {
+                HStack(spacing: Constants.itemSpacing) {
+                    Image.folderBadgePlus
+                        .foregroundColor(Color.foregroundQuarterary)
+                    Text(StringResource.newGroup.localized)
+                        .foregroundColor(Color.textPrimary)
+                        .font(Font.customInterMedium(size: 16))
+                }
+            }
+        )
     }
 
     var groupItems: some View {
-        ForEach(groups, id: \.self) { group in
-            Button(action: {}) {
-                item(name: group)
-            }
-        }
-    }
-
-    func item(name: String) -> some View {
-        HStack(spacing: Constants.itemSpacing) {
-            Image.folderBadgePlus
-                .foregroundColor(Color.foregroundQuarterary)
-            Text(name)
-                .foregroundColor(Color.textPrimary)
-                .font(Font.customInterMedium(size: 16))
+        ForEach(groups, id: \.id) { group in
+            Button(
+                action: {
+                    groupName = group.name
+                    onSelectedGroupAction(group)
+                },
+                label: {
+                    Text(group.name)
+                        .foregroundColor(Color.textPrimary)
+                        .font(Font.customInterMedium(size: 16))
+                }
+            )
         }
     }
 }

--- a/ARK Rate/Sources/Core/Presentation/Extensions/TypeAliases.swift
+++ b/ARK Rate/Sources/Core/Presentation/Extensions/TypeAliases.swift
@@ -1,3 +1,4 @@
 typealias ButtonAction = () -> Void
+typealias SelectedAction<T> = (T) -> Void
 typealias TitleSubtitlePair = (title: String, subtitle: String)
 typealias ButtonConfiguration = (title: String, action: ButtonAction)

--- a/ARK Rate/Sources/Core/Presentation/Storybook/Storybook.swift
+++ b/ARK Rate/Sources/Core/Presentation/Storybook/Storybook.swift
@@ -45,18 +45,6 @@ struct Storybook: PreviewProvider {
                     deleteButtonAction: {}
                 )
                     .padding(.horizontal, Constants.spacing)
-
-                LineDivider()
-
-                Text("GroupMenuView")
-                GroupMenuView(groups: .constant([]), addGroupAction: {})
-                    .padding(.horizontal, Constants.spacing)
-                GroupMenuView(groups: .constant([
-                    "Group 1",
-                    "Group 2",
-                    "Group 3"
-                ]), addGroupAction: {})
-                .padding(.horizontal, Constants.spacing)
             }
             .padding(.bottom, Constants.spacing)
         }

--- a/ARK Rate/Sources/Features/Quick/AddGroupModal/AddGroupModal.swift
+++ b/ARK Rate/Sources/Features/Quick/AddGroupModal/AddGroupModal.swift
@@ -83,7 +83,7 @@ private extension AddGroupModal {
             ZStack {
                 TextField(StringResource.createGroupPlaceholder.localized, text: $groupName)
                     .multilineTextAlignment(.leading)
-                    .foregroundColor(Color.textPlaceholder)
+                    .foregroundColor(Color.textPrimary)
                     .font(Font.customInterRegular(size: 16))
                     .padding(.horizontal, 14)
             }
@@ -100,6 +100,7 @@ private extension AddGroupModal {
                 expandHorizontally: true,
                 action: confirmButtonAction
             )
+            .modifier(DisabledModifier(disabled: groupName.isEmpty))
             SecondaryButton(
                 title: StringResource.cancel.localized,
                 expandHorizontally: true,

--- a/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationView.swift
+++ b/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationView.swift
@@ -56,9 +56,13 @@ private extension AddQuickCalculationView {
                 action: { store.send(.addOutputCurrencyButtonTapped) }
             )
             GroupMenuView(
-                groups: .constant([]),
+                groupName: .constant(store.selectedGroup?.name ?? StringResource.newGroup.localized),
+                groups: store.groups.elements,
                 addGroupAction: {
                     isShowingAddGroupModal = true
+                },
+                onSelectedGroupAction: { group in
+                    store.send(.onSelectedGroup(group))
                 }
             )
         }
@@ -117,12 +121,15 @@ private extension AddQuickCalculationView {
                     .zIndex(Constants.modalBackgroundZIndex)
                 AddGroupModal(
                     groupName: Binding(
-                        get: { store.groupName },
-                        set: { newValue in store.send(.updateGroupName(newValue)) }
+                        get: { store.addingGroupName },
+                        set: { newValue in store.send(.updateAddingGroupName(newValue)) }
                     ),
                     closeButtonAction: closeAction,
                     cancelButtonAction: closeAction,
-                    confirmButtonAction: {}
+                    confirmButtonAction: {
+                        closeAction()
+                        store.send(.createGroup)
+                    }
                 )
                 .zIndex(Constants.modalZIndex)
             }
@@ -148,6 +155,7 @@ private extension AddQuickCalculationView {
         case inputValue = "input_value"
         case result
         case newCurrency = "new_currency"
+        case newGroup = "new_group"
         case save
 
         var localized: String {

--- a/ARK Rate/Sources/Features/Quick/GroupDisplayModel.swift
+++ b/ARK Rate/Sources/Features/Quick/GroupDisplayModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct GroupDisplayModel: Identifiable, Equatable {
+
+    // MARK: - Properties
+
+    let id: UUID
+    let name: String
+    let displayOrder: Int?
+
+    // MARK: - Initialization
+
+    init(
+        id: UUID,
+        name: String,
+        displayOrder: Int?
+    ) {
+        self.id = id
+        self.name = name
+        self.displayOrder = displayOrder
+    }
+}

--- a/ARK Rate/Sources/Features/Quick/QuickFeature.swift
+++ b/ARK Rate/Sources/Features/Quick/QuickFeature.swift
@@ -38,19 +38,13 @@ struct QuickFeature {
         case deleteCalculationButtonTapped(id: UUID?)
         case calculationItemSelected(QuickCalculationDisplayModel?)
         case searchTextUpdated(String)
+        case addDefaultQuickCalculationGroup
         case showToastMessage(QuickToastContext)
         case clearToastMessage(QuickToastContext)
         case toastMessageActionButtonTapped(QuickToastContext)
         case hideTabbar
         case showTabbar
         case destination(PresentationAction<Destination.Action>)
-    }
-
-    // MARK: - Constants
-
-    private enum Constants {
-        static let toastAppearDelay: UInt64 = 350_000_000
-        static let toastAutoClearDelay: UInt64 = 10_000_000_000
     }
 
     // MARK: - Properties
@@ -61,6 +55,7 @@ struct QuickFeature {
     @Dependency(\.currencyCalculationUseCase) var currencyCalculationUseCase
     @Dependency(\.togglePinnedCalculationUseCase) var togglePinnedCalculationUseCase
     @Dependency(\.quickCalculationRepository) var quickCalculationRepository
+    @Dependency(\.quickCalculationGroupRepository) var quickCalculationGroupRepository
 
     // MARK: - Reducer
 
@@ -81,6 +76,7 @@ struct QuickFeature {
             case .deleteCalculationButtonTapped(let id): deleteCalculationButtonTapped(&state, id)
             case .calculationItemSelected(let calculation): calculationItemSelected(&state, calculation)
             case .searchTextUpdated(let searchText): searchTextUpdated(&state, searchText)
+            case .addDefaultQuickCalculationGroup: addDefaultQuickCalculationGroup(&state)
             case .showToastMessage(let context): showToastMessage(&state, context)
             case .clearToastMessage(let context): clearToastMessage(&state, context)
             case .toastMessageActionButtonTapped(let context): toastMessageActionButtonTapped(&state, context)
@@ -222,6 +218,15 @@ private extension QuickFeature {
         return Effect.none
     }
 
+    func addDefaultQuickCalculationGroup(_ state: inout State) -> Effect<Action> {
+        let group = QuickCalculationGroup(
+            name: StringResource.default.localized,
+            displayOrder: 0
+        )
+        try? quickCalculationGroupRepository.save(group)
+        return Effect.none
+    }
+
     func showToastMessage(_ state: inout State, _ context: QuickToastContext) -> Effect<Action> {
         state.toastMessages.append(context)
         return Effect.run { send in
@@ -280,3 +285,21 @@ extension QuickFeature {
 // MARK: -
 
 extension QuickFeature.Destination.State: Equatable {}
+
+// MARK: - Constants
+
+private extension QuickFeature {
+
+    enum Constants {
+        static let toastAppearDelay: UInt64 = 350_000_000
+        static let toastAutoClearDelay: UInt64 = 10_000_000_000
+    }
+
+    enum StringResource: String.LocalizationValue {
+        case `default`
+
+        var localized: String {
+            String(localized: rawValue)
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
[Quick] Create Add group modal

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Add Default group
- Create custom group
- Assign Group to Quick Calculation when Adding/Editing/Reusing

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| Light Mode | Dark Mode |
|------------|------------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-16 at 21 25 04](https://github.com/user-attachments/assets/1807086d-02f0-41ff-af55-9ed50c0870f3) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-16 at 21 25 09](https://github.com/user-attachments/assets/f8ce389a-ff51-41f8-a0a8-6ed76546bb09) |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[[Quick] Implement Add group feature for Add new calculation screen](https://app.asana.com/1/1207783906637200/task/1209638463619209?focus=true)