### PR TITLE
[Quick]  Show Groups to Quick screen

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,23 +1,33 @@
 # Configure key linting rules
-line_length: 150 # Maximum allowed characters per line
+line_length: 150    # Maximum allowed characters per line
 type_body_length:
-  warning: 300   # Show warning if class/struct body exceeds 300 lines
-  error: 400     # Show error if body exceeds 400 lines
+  warning: 300      # Show warning if class/struct body exceeds 300 lines
+  error: 400        # Show error if body exceeds 400 lines
+file_length: 1000
 identifier_name:
-  min_length: 2  # Variable and function names must have at least 2 characters
-  max_length: 40 # Maximum identifier length is 40 characters
+  min_length: 2     # Variable and function names must have at least 2 characters
+  max_length: 40    # Maximum identifier length is 40 characters
+function_parameter_count:
+  warning: 8
+  error: 10
+  ignores_default_parameters: true
+function_body_length:
+  warning: 80       # Warn if over 80 lines
+  error: 100        # Error if over 100 lines
+  ignores_comments: true        # Optional: don't count comments
+  ignores_empty_lines: true     # Optional: don't count blank lines
 
 # Enable rules that SwiftLint does not enforce by default
 opt_in_rules:
-  - empty_count       # Prefer `.isEmpty` instead of `.count == 0`
-  - closure_spacing   # Ensure proper spacing in closures
+  - empty_count      # Prefer `.isEmpty` instead of `.count == 0`
+  - closure_spacing  # Ensure proper spacing in closures
 
 # Disable specific rules
 disabled_rules:
-  - force_cast          # Do not warn about forced casting (as!)
-  - force_try           # Do not warn about force try (!)
+  - force_cast       # Do not warn about forced casting (as!)
+  - force_try        # Do not warn about force try (!)
   - nesting
 
 analyzer_rules:
-  - explicit_self     # Require `self.` when accessing instance properties
-  - unused_import     # Remove unused imports
+  - explicit_self    # Require `self.` when accessing instance properties
+  - unused_import    # Remove unused imports

--- a/ARK Rate/Sources/App/AppDependencies.swift
+++ b/ARK Rate/Sources/App/AppDependencies.swift
@@ -17,7 +17,12 @@ extension DependencyValues {
         set { self[LoadQuickCalculationsUseCaseKey.self] = newValue }
     }
 
-    var loadQuickCalculationGroupsUseCaseKey: LoadQuickCalculationGroupsUseCase {
+    var saveQuickCalculationUseCase: SaveQuickCalculationUseCase {
+        get { self[SaveQuickCalculationUseCaseKey.self] }
+        set { self[SaveQuickCalculationUseCaseKey.self] = newValue }
+    }
+
+    var loadQuickCalculationGroupsUseCase: LoadQuickCalculationGroupsUseCase {
         get { self[LoadQuickCalculationGroupsUseCaseKey.self] }
         set { self[LoadQuickCalculationGroupsUseCaseKey.self] = newValue }
     }
@@ -113,9 +118,20 @@ private enum LoadFrequentCurrenciesUseCaseKey: DependencyKey {
 private enum LoadQuickCalculationsUseCaseKey: DependencyKey {
 
     static let liveValue: LoadQuickCalculationsUseCase = LoadQuickCalculationsUseCase(
+        metadataRepository: DependencyValues._current.metadataRepository,
         quickCalculationRepository: DependencyValues._current.quickCalculationRepository,
-        currencyCalculationUseCase: DependencyValues._current.currencyCalculationUseCase,
-        metadataRepository: DependencyValues._current.metadataRepository
+        currencyCalculationUseCase: DependencyValues._current.currencyCalculationUseCase
+    )
+}
+
+// MARK: - SaveQuickCalculationUseCase
+
+private enum SaveQuickCalculationUseCaseKey: DependencyKey {
+
+    static let liveValue: SaveQuickCalculationUseCase = SaveQuickCalculationUseCase(
+        quickCalculationRepository: DependencyValues._current.quickCalculationRepository,
+        quickCalculationGroupRepository: DependencyValues._current.quickCalculationGroupRepository,
+        currencyStatisticRepository: DependencyValues._current.currencyStatisticRepository
     )
 }
 

--- a/ARK Rate/Sources/App/AppFeature.swift
+++ b/ARK Rate/Sources/App/AppFeature.swift
@@ -59,7 +59,7 @@ private extension AppFeature {
         var effects: [Effect<Action>] = [.send(.currenciesAction(.fetchCurrencies))]
         if !metadataRepository.hasLaunchedBefore() {
             metadataRepository.recordHasLaunchedBefore()
-            effects.append(.send(.quickAction(.addDefaultQuickCalculationGroup)))
+            effects.append(.send(.quickAction(.addDefaultGroup)))
         }
         return Effect.merge(effects)
     }

--- a/ARK Rate/Sources/Core/Data/DTO/QuickCalculationDTO.swift
+++ b/ARK Rate/Sources/Core/Data/DTO/QuickCalculationDTO.swift
@@ -11,5 +11,5 @@ struct QuickCalculationDTO {
     let inputCurrencyAmount: Decimal
     let outputCurrencyCodes: [String]
     let outputCurrencyAmounts: [Decimal]
-    let group: QuickCalculationGroupDTO?
+    let group: QuickCalculationGroupDTO
 }

--- a/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationGroupLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationGroupLocalDataSource.swift
@@ -4,5 +4,6 @@ protocol QuickCalculationGroupLocalDataSource {
 
     func get() throws -> [QuickCalculationGroupDTO]
     func get(where id: UUID) throws -> QuickCalculationGroupDTO?
+    func get(where name: String) throws -> QuickCalculationGroupDTO?
     func save(_ group: QuickCalculationGroupDTO) throws
 }

--- a/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationLocalDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/DataSources/QuickCalculationLocalDataSource.swift
@@ -3,8 +3,8 @@ import Foundation
 protocol QuickCalculationLocalDataSource {
 
     func get(where id: UUID) throws -> QuickCalculationDTO?
-    func get() throws -> [QuickCalculationDTO]
-    func getWherePinned() throws -> [QuickCalculationDTO]
+    func get(where groupId: UUID) throws -> [QuickCalculationDTO]
+    func getPinned(where groupId: UUID) throws -> [QuickCalculationDTO]
     func save(_ calculation: QuickCalculationDTO) throws
     func delete(where id: UUID) throws -> QuickCalculationDTO?
 }

--- a/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationModel.swift
+++ b/ARK Rate/Sources/Core/Data/Local/Models/QuickCalculationModel.swift
@@ -14,7 +14,7 @@ final class QuickCalculationModel {
     var outputCurrencyCodes: [String]
     var outputCurrencyAmounts: [Decimal]
 
-    @Relationship var group: QuickCalculationGroupModel?
+    @Relationship var group: QuickCalculationGroupModel
 
     // MARK: - Initialization
 
@@ -26,7 +26,7 @@ final class QuickCalculationModel {
         inputCurrencyAmount: Decimal,
         outputCurrencyCodes: [String],
         outputCurrencyAmounts: [Decimal],
-        group: QuickCalculationGroupModel?
+        group: QuickCalculationGroupModel
     ) {
         self.id = id
         self.pinnedDate = pinnedDate

--- a/ARK Rate/Sources/Core/Data/Local/QuickCalculationGroupSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/QuickCalculationGroupSwiftDataDataSource.swift
@@ -14,10 +14,20 @@ struct QuickCalculationGroupSwiftDataDataSource: QuickCalculationGroupLocalDataS
         return model.map(\.toQuickCalculationGroupDTO)
     }
 
+    func get(where name: String) throws -> QuickCalculationGroupDTO? {
+        let model: QuickCalculationGroupModel? = try SwiftDataManager.shared.get(predicate: #Predicate { $0.name == name })
+        return model.map(\.toQuickCalculationGroupDTO)
+    }
+
     func save(_ group: QuickCalculationGroupDTO) throws {
+        let id = group.id
         let name = group.name
         let model = group.toQuickCalculationGroupModel
-        if let fetchedModel: QuickCalculationGroupModel = try SwiftDataManager.shared.get(predicate: #Predicate { $0.name == name }) {
+        if let fetchedModel: QuickCalculationGroupModel = try SwiftDataManager.shared.get(predicate: #Predicate { $0.id == id }) {
+            fetchedModel.name = model.name
+            fetchedModel.displayOrder = model.displayOrder
+            try SwiftDataManager.shared.save()
+        } else if let fetchedModel: QuickCalculationGroupModel = try SwiftDataManager.shared.get(predicate: #Predicate { $0.name == name }) {
             fetchedModel.displayOrder = model.displayOrder
             try SwiftDataManager.shared.save()
         } else {

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -13,7 +13,7 @@ extension QuickCalculation {
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
             outputCurrencyAmounts: outputCurrencyAmounts,
-            group: group?.toQuickCalculationGroupDTO
+            group: group.toQuickCalculationGroupDTO
         )
     }
 
@@ -64,7 +64,7 @@ extension QuickCalculationDTO {
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
             outputCurrencyAmounts: outputCurrencyAmounts,
-            group: group?.toQuickCalculationGroup
+            group: group.toQuickCalculationGroup
         )
     }
 
@@ -77,7 +77,7 @@ extension QuickCalculationDTO {
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
             outputCurrencyAmounts: outputCurrencyAmounts,
-            group: group?.toQuickCalculationGroupModel
+            group: group.toQuickCalculationGroupModel
         )
     }
 }
@@ -95,7 +95,7 @@ extension QuickCalculationModel {
             inputCurrencyAmount: inputCurrencyAmount,
             outputCurrencyCodes: outputCurrencyCodes,
             outputCurrencyAmounts: outputCurrencyAmounts,
-            group: group?.toQuickCalculationGroupDTO
+            group: group.toQuickCalculationGroupDTO
         )
     }
 }

--- a/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationGroupRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationGroupRepositoryImpl.swift
@@ -16,6 +16,10 @@ struct QuickCalculationGroupRepositoryImpl: QuickCalculationGroupRepository {
         try localDataSource.get(where: id).map(\.toQuickCalculationGroup)
     }
 
+    func get(where name: String) throws -> QuickCalculationGroup? {
+        try localDataSource.get(where: name).map(\.toQuickCalculationGroup)
+    }
+
     func save(_ group: QuickCalculationGroup) throws {
         try localDataSource.save(group.toQuickCalculationGroupDTO)
     }

--- a/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
+++ b/ARK Rate/Sources/Core/Data/Repositories/QuickCalculationRepositoryImpl.swift
@@ -12,12 +12,12 @@ struct QuickCalculationRepositoryImpl: QuickCalculationRepository {
         try localDataSource.get(where: id).map(\.toQuickCalculation)
     }
 
-    func get() throws -> [QuickCalculation] {
-        try localDataSource.get().map(\.toQuickCalculation)
+    func get(where groupId: UUID) throws -> [QuickCalculation] {
+        try localDataSource.get(where: groupId).map(\.toQuickCalculation)
     }
 
-    func getWherePinned() throws -> [QuickCalculation] {
-        try localDataSource.getWherePinned().map(\.toQuickCalculation)
+    func getPinned(where groupId: UUID) throws -> [QuickCalculation] {
+        try localDataSource.getPinned(where: groupId).map(\.toQuickCalculation)
     }
 
     func save(_ calculation: QuickCalculation) throws {

--- a/ARK Rate/Sources/Core/Domain/Entities/QuickCalculation.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/QuickCalculation.swift
@@ -11,7 +11,7 @@ struct QuickCalculation: Equatable {
     let inputCurrencyAmount: Decimal
     let outputCurrencyCodes: [String]
     let outputCurrencyAmounts: [Decimal]
-    let group: QuickCalculationGroup?
+    let group: QuickCalculationGroup
 
     // MARK: - Initialization
 
@@ -23,7 +23,7 @@ struct QuickCalculation: Equatable {
         inputCurrencyAmount: Decimal,
         outputCurrencyCodes: [String],
         outputCurrencyAmounts: [Decimal],
-        group: QuickCalculationGroup?
+        group: QuickCalculationGroup
     ) {
         self.id = id
         self.pinnedDate = pinnedDate

--- a/ARK Rate/Sources/Core/Domain/Entities/QuickCalculationGroup.swift
+++ b/ARK Rate/Sources/Core/Domain/Entities/QuickCalculationGroup.swift
@@ -2,6 +2,8 @@ import Foundation
 
 struct QuickCalculationGroup: Equatable {
 
+    static let defaultGroupName = "default"
+
     // MARK: - Properties
 
     let id: UUID

--- a/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationGroupRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationGroupRepository.swift
@@ -4,5 +4,6 @@ protocol QuickCalculationGroupRepository {
 
     func get() throws -> [QuickCalculationGroup]
     func get(where id: UUID) throws -> QuickCalculationGroup?
+    func get(where name: String) throws -> QuickCalculationGroup?
     func save(_ group: QuickCalculationGroup) throws
 }

--- a/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationRepository.swift
+++ b/ARK Rate/Sources/Core/Domain/Repositories/QuickCalculationRepository.swift
@@ -3,8 +3,8 @@ import Foundation
 protocol QuickCalculationRepository {
 
     func get(where id: UUID) throws -> QuickCalculation?
-    func get() throws -> [QuickCalculation]
-    func getWherePinned() throws -> [QuickCalculation]
+    func get(where groupId: UUID) throws -> [QuickCalculation]
+    func getPinned(where groupId: UUID) throws -> [QuickCalculation]
     func save(_ calculation: QuickCalculation) throws
     func delete(where id: UUID) throws -> QuickCalculation?
 }

--- a/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/LoadQuickCalculationsUseCase.swift
@@ -4,36 +4,42 @@ struct LoadQuickCalculationsUseCase {
 
     // MARK: - Properties
 
+    let metadataRepository: MetadataRepository
     let quickCalculationRepository: QuickCalculationRepository
     let currencyCalculationUseCase: CurrencyCalculationUseCase
-    let metadataRepository: MetadataRepository
 
     // MARK: - Methods
 
-    func getCalculatedCalculations() -> [QuickCalculation] {
-        (try? quickCalculationRepository.get().sorted { $0.calculatedDate > $1.calculatedDate }) ?? []
+    func getCalculatedCalculations(groupBy groups: [QuickCalculationGroup]) -> [[QuickCalculation]] {
+        groups
+            .map { group in
+                (try? quickCalculationRepository
+                    .get(where: group.id)
+                    .sorted { $0.calculatedDate > $1.calculatedDate }
+                ) ?? []
+            }
     }
 
-    func getPinnedCalculations() -> [QuickCalculation] {
-        do {
-            return try quickCalculationRepository.getWherePinned()
-                .map { calculation in
-                    var outputCurrencyAmounts = calculation.outputCurrencyAmounts
-                    for (index, outputCurrencyCode) in calculation.outputCurrencyCodes.enumerated() {
-                        outputCurrencyAmounts[index] = currencyCalculationUseCase.execute(
-                            inputCurrencyCode: calculation.inputCurrencyCode,
-                            inputCurrencyAmount: calculation.inputCurrencyAmount,
-                            outputCurrencyCode: outputCurrencyCode
+    func getPinnedCalculations(groupBy groups: [QuickCalculationGroup]) -> [[QuickCalculation]] {
+        groups
+            .map { group in
+                (try? quickCalculationRepository.getPinned(where: group.id)
+                    .map { calculation in
+                        var outputCurrencyAmounts = calculation.outputCurrencyAmounts
+                        for (index, outputCurrencyCode) in calculation.outputCurrencyCodes.enumerated() {
+                            outputCurrencyAmounts[index] = currencyCalculationUseCase.execute(
+                                inputCurrencyCode: calculation.inputCurrencyCode,
+                                inputCurrencyAmount: calculation.inputCurrencyAmount,
+                                outputCurrencyCode: outputCurrencyCode
+                            )
+                        }
+                        return calculation.toQuickCalculation(
+                            calculatedDate: metadataRepository.lastCurrenciesFetchDate() ?? Date(),
+                            outputCurrencyAmounts: outputCurrencyAmounts
                         )
                     }
-                    return calculation.toQuickCalculation(
-                        calculatedDate: metadataRepository.lastCurrenciesFetchDate() ?? Date(),
-                        outputCurrencyAmounts: outputCurrencyAmounts
-                    )
-                }
-                .sorted { $0.pinnedDate! > $1.pinnedDate! }
-        } catch {
-            return []
-        }
+                    .sorted { $0.pinnedDate! > $1.pinnedDate! }
+                ) ?? []
+            }
     }
 }

--- a/ARK Rate/Sources/Core/Domain/UseCases/SaveQuickCalculationUseCase.swift
+++ b/ARK Rate/Sources/Core/Domain/UseCases/SaveQuickCalculationUseCase.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct SaveQuickCalculationUseCase {
+
+    // MARK: - Properties
+
+    let quickCalculationRepository: QuickCalculationRepository
+    let quickCalculationGroupRepository: QuickCalculationGroupRepository
+    let currencyStatisticRepository: CurrencyStatisticRepository
+
+    // MARK: - Methods
+
+    func execute(
+        id: UUID?,
+        inputCurrencyCode: String,
+        inputCurrencyAmount: Decimal,
+        outputCurrencyCodes: [String],
+        outputCurrencyAmounts: [Decimal],
+        groupId: UUID
+    ) -> QuickCalculation? {
+        guard let group = try? quickCalculationGroupRepository.get(where: groupId) else { return nil }
+        let pinnedDate = id.flatMap { try? quickCalculationRepository.get(where: $0)?.pinnedDate }
+        let calculationId = id ?? UUID()
+        let quickCalculation = QuickCalculation(
+            id: calculationId,
+            pinnedDate: pinnedDate,
+            inputCurrencyCode: inputCurrencyCode,
+            inputCurrencyAmount: inputCurrencyAmount,
+            outputCurrencyCodes: outputCurrencyCodes,
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group
+        )
+        let currencyStatistics = quickCalculation.toCurrencyStatistics
+        try? quickCalculationRepository.save(quickCalculation)
+        try? currencyStatisticRepository.save(currencyStatistics)
+        return quickCalculation
+    }
+}

--- a/ARK Rate/Sources/Core/Presentation/Components/GroupMenuView.swift
+++ b/ARK Rate/Sources/Core/Presentation/Components/GroupMenuView.swift
@@ -7,7 +7,7 @@ struct GroupMenuView: View {
     @Binding var groupName: String
     let groups: [GroupDisplayModel]
     let addGroupAction: ButtonAction
-    let onSelectedGroupAction: SelectedAction<GroupDisplayModel>
+    let onSelectedGroupAction: ActionHandler<GroupDisplayModel>
 
     // MARK: - Body
 
@@ -56,11 +56,11 @@ private extension GroupMenuView {
         ForEach(groups, id: \.id) { group in
             Button(
                 action: {
-                    groupName = group.name
+                    groupName = group.displayName
                     onSelectedGroupAction(group)
                 },
                 label: {
-                    Text(group.name)
+                    Text(group.displayName)
                         .foregroundColor(Color.textPrimary)
                         .font(Font.customInterMedium(size: 16))
                 }

--- a/ARK Rate/Sources/Core/Presentation/Extensions/NSItemProvider+Extensions.swift
+++ b/ARK Rate/Sources/Core/Presentation/Extensions/NSItemProvider+Extensions.swift
@@ -1,0 +1,22 @@
+import UniformTypeIdentifiers
+
+extension NSItemProvider {
+
+    func loadDataRepresentation(_ identifier: String) async -> Int? {
+        guard let stringValue: String = await loadDataRepresentation(identifier),
+              let intValue = Int(stringValue) else { return nil }
+        return intValue
+    }
+
+    func loadDataRepresentation(_ identifier: String) async -> String? {
+        await withCheckedContinuation { continuation in
+            loadDataRepresentation(forTypeIdentifier: identifier) { data, _ in
+                if let data, let text = String(data: data, encoding: .utf8) {
+                    continuation.resume(returning: text)
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+}

--- a/ARK Rate/Sources/Core/Presentation/Extensions/TypeAliases.swift
+++ b/ARK Rate/Sources/Core/Presentation/Extensions/TypeAliases.swift
@@ -1,4 +1,8 @@
+import SwiftUI
+
+typealias Frames = [Int: CGRect]
 typealias ButtonAction = () -> Void
-typealias SelectedAction<T> = (T) -> Void
+typealias ActionHandler<T> = (T) -> Void
+typealias ReorderingAction = (Int, Int) -> Void
 typealias TitleSubtitlePair = (title: String, subtitle: String)
 typealias ButtonConfiguration = (title: String, action: ButtonAction)

--- a/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationView.swift
+++ b/ARK Rate/Sources/Features/Quick/AddQuickCalculation/AddQuickCalculationView.swift
@@ -56,13 +56,13 @@ private extension AddQuickCalculationView {
                 action: { store.send(.addOutputCurrencyButtonTapped) }
             )
             GroupMenuView(
-                groupName: .constant(store.selectedGroup?.name ?? StringResource.newGroup.localized),
-                groups: store.groups.elements,
+                groupName: .constant(store.selectedCalculationGroup?.displayName ?? StringResource.newGroup.localized),
+                groups: store.calculationGroups.elements,
                 addGroupAction: {
                     isShowingAddGroupModal = true
                 },
                 onSelectedGroupAction: { group in
-                    store.send(.onSelectedGroup(group))
+                    store.send(.onSelectedCalculationGroup(group))
                 }
             )
         }
@@ -121,14 +121,14 @@ private extension AddQuickCalculationView {
                     .zIndex(Constants.modalBackgroundZIndex)
                 AddGroupModal(
                     groupName: Binding(
-                        get: { store.addingGroupName },
-                        set: { newValue in store.send(.updateAddingGroupName(newValue)) }
+                        get: { store.addingCalculationGroupName },
+                        set: { newValue in store.send(.updateAddingCalculationGroupName(newValue)) }
                     ),
                     closeButtonAction: closeAction,
                     cancelButtonAction: closeAction,
                     confirmButtonAction: {
                         closeAction()
-                        store.send(.createGroup)
+                        store.send(.createCalculationGroup)
                     }
                 )
                 .zIndex(Constants.modalZIndex)

--- a/ARK Rate/Sources/Features/Quick/GroupDisplayModel.swift
+++ b/ARK Rate/Sources/Features/Quick/GroupDisplayModel.swift
@@ -5,18 +5,27 @@ struct GroupDisplayModel: Identifiable, Equatable {
     // MARK: - Properties
 
     let id: UUID
-    let name: String
     let displayOrder: Int?
+    let displayName: String
 
     // MARK: - Initialization
 
-    init(
-        id: UUID,
-        name: String,
-        displayOrder: Int?
-    ) {
+    init(id: UUID, name: String, displayOrder: Int?) {
         self.id = id
-        self.name = name
+        self.displayName = if !Constants.defaultGroupKeys.contains(name) {
+            name
+        } else {
+            NSLocalizedString(name, comment: "")
+        }
         self.displayOrder = displayOrder
+    }
+}
+
+// MARK: - Constants
+
+private extension GroupDisplayModel {
+
+    enum Constants {
+        static let defaultGroupKeys: Set<String> = [QuickCalculationGroup.defaultGroupName]
     }
 }


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
[Quick] Show Groups to Quick screen

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Show Groups to Quick screen
- Prepare for Reorder feature

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| Light Mode | Dark Mode |
|------------|------------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-25 at 14 25 47](https://github.com/user-attachments/assets/5eaf3b20-ee82-436d-999c-e851f47c0ed7) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-25 at 14 25 43](https://github.com/user-attachments/assets/f843f0cf-4b6b-4387-83b1-38615d41dab5) |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[[Quick] Implement Add group feature for Add new calculation screen](https://app.asana.com/1/1207783906637200/task/1209638463619209?focus=true)