### PR TITLE
Fix crash by assigning context-managed group in QuickCalculationModel

### DIFF
--- a/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
+++ b/ARK Rate/Sources/Core/Data/Local/QuickCalculationSwiftDataDataSource.swift
@@ -29,7 +29,7 @@ struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
         let groupId = calculation.group.id
         guard let group: QuickCalculationGroupModel = try SwiftDataManager.shared.get(predicate: #Predicate { $0.id == groupId }) else { return }
         let id = calculation.id
-        let model = calculation.toQuickCalculationModel
+        let model = calculation.toQuickCalculationModel(group: group)
         if let fetchedModel: QuickCalculationModel = try SwiftDataManager.shared.get(predicate: #Predicate { $0.id == id }) {
             fetchedModel.pinnedDate = model.pinnedDate
             fetchedModel.calculatedDate = model.calculatedDate
@@ -40,7 +40,6 @@ struct QuickCalculationSwiftDataDataSource: QuickCalculationLocalDataSource {
             fetchedModel.group = group
             try SwiftDataManager.shared.save()
         } else {
-            model.group = group
             try SwiftDataManager.shared.insert(model)
         }
     }

--- a/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
+++ b/ARK Rate/Sources/Core/Data/Mappers/QuickCalculationMapper.swift
@@ -80,6 +80,19 @@ extension QuickCalculationDTO {
             group: group.toQuickCalculationGroupModel
         )
     }
+
+    func toQuickCalculationModel(group: QuickCalculationGroupModel) -> QuickCalculationModel {
+        QuickCalculationModel(
+            id: id,
+            pinnedDate: pinnedDate,
+            calculatedDate: calculatedDate,
+            inputCurrencyCode: inputCurrencyCode,
+            inputCurrencyAmount: inputCurrencyAmount,
+            outputCurrencyCodes: outputCurrencyCodes,
+            outputCurrencyAmounts: outputCurrencyAmounts,
+            group: group
+        )
+    }
 }
 
 // MARK: -


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
Fix crash by assigning context-managed group in QuickCalculationModel

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Fix crash by assigning context-managed group in QuickCalculationModel

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[Crash when calculating - Jun 20, 2025 at 6:05 PM](https://app.asana.com/1/1207783906637200/task/1210599755932174?focus=true)