### PR TITLE
Omit on to other numbers in elapsed time string

### DIFF
--- a/ARK Rate/Localizable.xcstrings
+++ b/ARK Rate/Localizable.xcstrings
@@ -131,7 +131,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Calculated on %@ ago"
+            "value" : "Calculated %@ ago"
           }
         },
         "ru" : {


### PR DESCRIPTION
## 📌 Description  
<!-- Briefly describe the purpose of this PR and key changes made. -->
Fixes elapsed one week string issue

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- Omit on to other numbers in elapsed time string

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Open "ARK Rate" app from iPhone or simulator.

## 📸 Screenshots / Demo (if applicable)  
<!-- Add screenshots or a demo video if needed. -->
| English | Russian |
|------------|------------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-20 at 09 54 34" src="https://github.com/user-attachments/assets/73d6674c-05c7-4824-b0ab-5e8cac658625" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-20 at 09 55 29" src="https://github.com/user-attachments/assets/7b58114e-f8f9-4b15-9952-2cc023f2e378" /> |

## 🔗 Related Tickets / Issues  
<!-- Link any related tasks or issues. -->
[Calculation time format fix implementation — iOS](https://app.asana.com/1/1207783906637200/task/1210837737641714?focus=true)